### PR TITLE
Add AnvilGUI support

### DIFF
--- a/plugins/civmodcore-paper/build.gradle.kts
+++ b/plugins/civmodcore-paper/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 	api("com.zaxxer:HikariCP:5.0.1")
 	api("co.aikar:taskchain-bukkit:3.7.2")
 	api("com.github.IPVP-MC:canvas:91ec97f076")
+	api("net.wesjd:anvilgui:1.9.2-SNAPSHOT")
 	api("org.apache.commons:commons-lang3:3.12.0")
 	api("org.apache.commons:commons-collections4:4.4")
 	api("com.google.code.findbugs:jsr305:3.0.2")

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/InventoryUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/InventoryUtils.java
@@ -8,11 +8,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import net.wesjd.anvilgui.AnvilGUI;
 import org.apache.commons.lang3.ArrayUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 public final class InventoryUtils {
@@ -236,4 +238,7 @@ public final class InventoryUtils {
 		return true;
 	}
 
+	public static @NotNull AnvilGUI.Builder newAnvilGui() {
+		return new AnvilGUI.Builder();
+	}
 }


### PR DESCRIPTION
Copied over from https://github.com/CivMC/CivModCore/pull/104

> Follows through on https://github.com/CivClassic/CivModCore/issues/42 and adds [WesJD/AnvilGUI](https://github.com/WesJD/AnvilGUI) support to CivModCore. As with the issue, this is not about replacing or refactoring chat prompts, but rather giving the option to use a more interfacey/Minecrafty way of achieving the same goal.