### PR TITLE
Remove asTranslatable

### DIFF
--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/entities/EntityUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/entities/EntityUtils.java
@@ -1,16 +1,12 @@
 package vg.civcraft.mc.civmodcore.entities;
 
 import com.google.common.base.Strings;
-import javax.annotation.Nonnull;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TranslatableComponent;
 import org.bukkit.entity.EntityType;
 
 /**
  * Class of static APIs for Entities.
  */
 public final class EntityUtils {
-
 	/**
 	 * Attempts to retrieve an entity type by its slug or id.
 	 *
@@ -35,13 +31,4 @@ public final class EntityUtils {
 		catch (final Throwable ignored) { }
 		return null;
 	}
-
-	/**
-	 * @param entityType The entity type to translate.
-	 * @return Returns a translatable component based on the given entity type.
-	 */
-	public static TranslatableComponent asTranslatable(@Nonnull final EntityType entityType) {
-		return Component.translatable(entityType.translationKey());
-	}
-
 }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/EnchantUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/EnchantUtils.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.translation.Translatable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.enchantments.Enchantment;
@@ -103,24 +103,15 @@ public final class EnchantUtils {
 	}
 
 	/**
-	 * @param enchant The enchantment to get a translatable component for.
-	 * @return Returns a translatable component for the given enchantment.
-	 */
-	@Nonnull
-	public static TranslatableComponent asTranslatable(@Nonnull final Enchantment enchant) {
-		return Component.translatable(enchant.translationKey());
-	}
-
-	/**
 	 * @param enchant The enchantment to get the name of.
 	 * @return Returns the name of the enchantment, or null.
 	 *
-	 * @deprecated Use {@link #asTranslatable(Enchantment)} instead.
+	 * @deprecated Use {@link Component#translatable(Translatable)} instead.
 	 */
 	@Nullable
 	@Deprecated
 	public static String getEnchantNiceName(@Nullable final Enchantment enchant) {
-		return enchant == null ? null : ChatUtils.stringify(asTranslatable(enchant));
+		return enchant == null ? null : ChatUtils.stringify(Component.translatable(enchant));
 	}
 
 	/**

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemUtils.java
@@ -8,7 +8,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.translation.Translatable;
 import org.bukkit.Material;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.inventory.ItemStack;
@@ -21,28 +21,18 @@ import vg.civcraft.mc.civmodcore.chat.ChatUtils;
  * Class of static APIs for Items. Replaces ISUtils.
  */
 public final class ItemUtils {
-
-	/**
-	 * @param item The item to get a translatable component for.
-	 * @return Returns a translatable component of the given item.
-	 */
-	@Nonnull
-	public static TranslatableComponent asTranslatable(@Nonnull final ItemStack item) {
-		return Component.translatable(item.translationKey());
-	}
-
 	/**
 	 * Gets the name of an item based off a material, e.g: POLISHED_GRANITE to Polished Granite
 	 *
 	 * @param material The material to get the name of.
 	 * @return Returns the material name.
 	 *
-	 * @deprecated Use {@link MaterialUtils#asTranslatable(Material)} instead.
+	 * @deprecated Use {@link Component#translatable(Translatable)} instead.
 	 */
 	@Deprecated
 	@Nonnull
 	public static String getItemName(@Nonnull final Material material) {
-		return ChatUtils.stringify(MaterialUtils.asTranslatable(Objects.requireNonNull(material)));
+		return ChatUtils.stringify(Component.translatable(Objects.requireNonNull(material)));
 	}
 
 	/**
@@ -51,12 +41,12 @@ public final class ItemUtils {
 	 * @param item The item to get the name of.
 	 * @return Returns the item's name.
 	 *
-	 * @deprecated Use {@link #asTranslatable(ItemStack)} instead.
+	 * @deprecated Use {@link Component#translatable(Translatable)} instead.
 	 */
 	@Deprecated
 	@Nullable
 	public static String getItemName(@Nullable final ItemStack item) {
-		return item == null ? null : ChatUtils.stringify(asTranslatable(item));
+		return item == null ? null : ChatUtils.stringify(Component.translatable(item));
 	}
 
 	/**

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MaterialUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MaterialUtils.java
@@ -6,12 +6,9 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TranslatableComponent;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.Tag;
-import org.bukkit.inventory.ItemStack;
 
 /**
  * <p>See <a href="https://github.com/Protonull/BukkitReport/tree/master/reports">BukkitReports</a>.</p>
@@ -41,18 +38,6 @@ public final class MaterialUtils {
 	@Nullable
 	public static Material getMaterial(@Nullable final String value) {
 		return StringUtils.isEmpty(value) ? null : Material.getMaterial(value.toUpperCase());
-	}
-
-	/**
-	 * {@link ItemUtils#asTranslatable(ItemStack)} is preferable since that will return a translatable based on
-	 * additional item data, such as Potion becoming Potion of Water Breathing or Potion of Regeneration.
-	 *
-	 * @param material The material to translate.
-	 * @return Returns a translatable component based on the given material.
-	 */
-	@Nonnull
-	public static TranslatableComponent asTranslatable(@Nonnull final Material material) {
-		return Component.translatable(material.translationKey());
 	}
 
 	/**

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/PotionUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/PotionUtils.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
-import net.minecraft.world.effect.MobEffect;
+import net.kyori.adventure.translation.Translatable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -51,29 +51,6 @@ public final class PotionUtils {
 	}
 
 	/**
-	 * @param effect The potion effect to get a translatable component for.
-	 * @return Returns a translatable component for the given potion effect.
-	 */
-	@SuppressWarnings("deprecation")
-	@Nonnull
-	public static TranslatableComponent asTranslatable(@Nonnull final PotionEffectType effect) {
-		final MobEffect mojang = MobEffect.byId(effect.getId());
-		assert mojang != null;
-		final String key = mojang.getDescriptionId(); // Gets the translation key
-		// If the obfuscation has changed, look for a method on MobEffectList like:
-		//
-		//    protected String b() {
-		//        if (this.d == null) {
-		//            this.d = SystemUtils.a("effect", IRegistry.V.getKey(this));
-		//        }
-		//        return this.d;
-		//    }
-		//
-		// then use whatever method calls that method
-		return Component.translatable(key);
-	}
-
-	/**
 	 * @param potion The potion type to get the name of.
 	 * @return Returns the name of the potion, or null.
 	 *
@@ -90,12 +67,11 @@ public final class PotionUtils {
 	 * @param effect The potion effect to get the name of.
 	 * @return Returns the name of the potion effect, or null.
 	 *
-	 * @deprecated Use {@link #asTranslatable(PotionEffectType)} instead.
+	 * @deprecated Use {@link Component#translatable(Translatable)} instead.
 	 */
 	@Deprecated
 	@Nullable
 	public static String getEffectNiceName(@Nullable final PotionEffectType effect) {
-		return effect == null ? null : ChatUtils.stringify(asTranslatable(effect));
+		return effect == null ? null : ChatUtils.stringify(Component.translatable(effect));
 	}
-
 }


### PR DESCRIPTION
Copied over from https://github.com/CivMC/CivModCore/pull/103

> Save for the PotionUtils class where some custom translation-finding stuff is, these methods can be entirely fobbed off to Kyori.