### PR TITLE
Don't use snapshots with getHolder

### DIFF
--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/InventoryListener.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/InventoryListener.java
@@ -19,7 +19,7 @@ public class InventoryListener implements Listener {
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onInventoryMoveItemEvent(InventoryMoveItemEvent event) {
 		Inventory fromInventory = event.getSource();
-		InventoryHolder fromHolder = fromInventory.getHolder();
+		InventoryHolder fromHolder = fromInventory.getHolder(false);
 		boolean isFromBlock = fromHolder instanceof Container || fromHolder instanceof DoubleChest;
 		boolean fromAtChunkBorder = false;
 		Location fromLocation = null;
@@ -33,7 +33,7 @@ public class InventoryListener implements Listener {
 		}
 
 		Inventory destInventory = event.getDestination();
-		InventoryHolder destHolder = destInventory.getHolder();
+		InventoryHolder destHolder = destInventory.getHolder(false);
 		boolean isDestBlock = destHolder instanceof Container || destHolder instanceof DoubleChest;
 		boolean destAtChunkBorder = false;
 		Location destLocation = null;
@@ -56,8 +56,8 @@ public class InventoryListener implements Listener {
 		if (isFromBlock) {
 			if (fromAtChunkBorder && fromHolder instanceof DoubleChest) {
 				DoubleChest doubleChest = (DoubleChest) fromHolder;
-				Location chestLocation = ((Chest) doubleChest.getLeftSide()).getLocation();
-				Location otherLocation = ((Chest) doubleChest.getRightSide()).getLocation();
+				Location chestLocation = ((Chest) doubleChest.getLeftSide(false)).getLocation();
+				Location otherLocation = ((Chest) doubleChest.getRightSide(false)).getLocation();
 				// [LagFix] If either side of the double chest is not loaded then the
 				// reinforcement cannot be retrieved
 				// [LagFix] without necessarily loading the chunk to check against reinforcement
@@ -75,8 +75,8 @@ public class InventoryListener implements Listener {
 		if (isDestBlock) {
 			if (destAtChunkBorder && destHolder instanceof DoubleChest) {
 				DoubleChest doubleChest = (DoubleChest) destHolder;
-				Location chestLocation = ((Chest) doubleChest.getLeftSide()).getLocation();
-				Location otherLocation = ((Chest) doubleChest.getRightSide()).getLocation();
+				Location chestLocation = ((Chest) doubleChest.getLeftSide(false)).getLocation();
+				Location otherLocation = ((Chest) doubleChest.getRightSide(false)).getLocation();
 				// [LagFix] If either side of the double chest is not loaded then the
 				// reinforcement cannot be retrieved
 				// [LagFix] without necessarily loading the chunk to check against reinforcement

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/listener/ExileListener.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/listener/ExileListener.java
@@ -379,7 +379,7 @@ public class ExileListener extends RuleListener implements Configurable {
 			if (item == null || !clickedTop) {
 				return;
 			}
-			holder = e.getView().getTopInventory().getHolder();
+			holder = e.getView().getTopInventory().getHolder(false);
 
 		} else if(action == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
 			item = e.getCurrentItem();
@@ -388,7 +388,7 @@ public class ExileListener extends RuleListener implements Configurable {
 				return;
 			}
 
-			holder = e.getView().getTopInventory().getHolder(); // we're canceling bottom
+			holder = e.getView().getTopInventory().getHolder(false); // we're canceling bottom
 			// inventory click but only if _top_ inventory is specific type.
 		} else {
 			return;

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -241,7 +241,7 @@ public class PlayerListener implements Listener, Configurable {
 	public void onInventoryPickupItem(InventoryPickupItemEvent e) {
 		ExilePearl pearl = pearlApi.getPearlFromItemStack(e.getItem().getItemStack());
 		if(pearl != null){
-			if (e.getInventory().getHolder() instanceof HopperMinecart) {
+			if (e.getInventory().getHolder(false) instanceof HopperMinecart) {
 				e.setCancelled(true);
 			} else if (e.getInventory().getType() == InventoryType.HOPPER) {
 				pearl.setHolder(e.getInventory().getLocation().getBlock());
@@ -388,7 +388,7 @@ public class PlayerListener implements Listener, Configurable {
 			if(pearl != null) {
 				boolean clickedTop = event.getView().convertSlot(slot) == slot;
 
-				InventoryHolder holder = clickedTop ? event.getView().getTopInventory().getHolder() : event.getView().getBottomInventory().getHolder();
+				InventoryHolder holder = clickedTop ? event.getView().getTopInventory().getHolder(false) : event.getView().getBottomInventory().getHolder(false);
 
 				updatePearlHolder(pearl, holder, event);
 
@@ -411,7 +411,7 @@ public class PlayerListener implements Listener, Configurable {
 		if (holder instanceof Chest) {
 			updatePearl(pearl, (Chest)holder);
 		} else if (holder instanceof DoubleChest) {
-			updatePearl(pearl, (Chest) ((DoubleChest) holder).getLeftSide());
+			updatePearl(pearl, (Chest) ((DoubleChest) holder).getLeftSide(false));
 		} else if (holder instanceof Furnace) {
 			updatePearl(pearl, (Furnace) holder);
 		} else if (holder instanceof Dispenser) {
@@ -564,7 +564,7 @@ public class PlayerListener implements Listener, Configurable {
 
 			if(pearl != null) {
 				boolean clickedTop = event.getRawSlot() < event.getView().getTopInventory().getSize();
-				InventoryHolder holder = clickedTop ? event.getView().getTopInventory().getHolder() : event.getView().getBottomInventory().getHolder();
+				InventoryHolder holder = clickedTop ? event.getView().getTopInventory().getHolder(false) : event.getView().getBottomInventory().getHolder(false);
 				if (holder != null) {
 					updatePearlHolder(pearl, holder, event);
 				}
@@ -576,7 +576,7 @@ public class PlayerListener implements Listener, Configurable {
 			if(pearl != null) {
 				boolean clickedTop = event.getRawSlot() < event.getView().getTopInventory().getSize();
 
-				InventoryHolder holder = !clickedTop ? event.getView().getTopInventory().getHolder() : event.getView().getBottomInventory().getHolder();
+				InventoryHolder holder = !clickedTop ? event.getView().getTopInventory().getHolder(false) : event.getView().getBottomInventory().getHolder(false);
 
 				// ShiftClicking into a furnace will not move the pearl into the furnace so the pearlHolder should not be updated
 				if (event.getClick().isShiftClick() && holder != null && holder.getInventory() instanceof FurnaceInventory) {
@@ -602,7 +602,7 @@ public class PlayerListener implements Listener, Configurable {
 			if(pearl != null) {
 				boolean clickedTop = event.getRawSlot() < event.getView().getTopInventory().getSize();
 
-				InventoryHolder holder = clickedTop ? event.getView().getTopInventory().getHolder() : event.getView().getBottomInventory().getHolder();
+				InventoryHolder holder = clickedTop ? event.getView().getTopInventory().getHolder(false) : event.getView().getBottomInventory().getHolder(false);
 
 				updatePearlHolder(pearl, holder, event);
 			}
@@ -622,7 +622,7 @@ public class PlayerListener implements Listener, Configurable {
 			if(pearl != null) {
 				boolean clickedTop = event.getRawSlot() < event.getView().getTopInventory().getSize();
 
-				InventoryHolder holder = clickedTop ? event.getView().getTopInventory().getHolder() : event.getView().getBottomInventory().getHolder();
+				InventoryHolder holder = clickedTop ? event.getView().getTopInventory().getHolder(false) : event.getView().getBottomInventory().getHolder(false);
 
 				updatePearlHolder(pearl, holder, event);
 			}


### PR DESCRIPTION
This uses 0.5%-1% of a tick by copying loads of data around that we never use, this uses the new getHolder(boolean) method added by https://github.com/PaperMC/Paper/pull/3535, which is much faster.