### PR TITLE
Add a fix for high despawn ranges

### DIFF
--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/DespawnFix.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/DespawnFix.java
@@ -17,7 +17,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.world.EntitiesUnloadEvent;
 
 /**
- Allows for high hard despawn distance and low simulation distance by forcible removing mobs
+ Allows for high hard despawn distance and low simulation distance by forcibly removing mobs
  that are inside the simulation distance yet, still in the hard despawn distance.
  */
 public class DespawnFix extends BasicHack {

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/DespawnFix.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/DespawnFix.java
@@ -1,0 +1,53 @@
+package com.programmerdan.minecraft.simpleadminhacks.hacks.basic;
+
+import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
+import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
+import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Ghast;
+import org.bukkit.entity.Hoglin;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Monster;
+import org.bukkit.entity.Phantom;
+import org.bukkit.entity.Shulker;
+import org.bukkit.entity.Slime;
+import org.bukkit.entity.Wither;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.world.EntitiesUnloadEvent;
+
+/**
+ Allows for high hard despawn distance and low simulation distance by forcible removing mobs
+ that are inside the simulation distance yet, still in the hard despawn distance.
+ */
+public class DespawnFix extends BasicHack {
+
+	public DespawnFix(SimpleAdminHacks plugin, BasicHackConfig config) {
+		super(plugin, config);
+	}
+
+	@EventHandler
+	public void on(EntitiesUnloadEvent event) {
+		for (Entity entity : event.getEntities()) {
+			if (!(entity instanceof LivingEntity living)) {
+				continue;
+			}
+
+			if (entity.getVehicle() != null) {
+				continue;
+			}
+
+			if (entity instanceof EnderDragon || entity instanceof Shulker || entity instanceof Wither) {
+				continue;
+			}
+
+			if (!(entity instanceof Monster || entity instanceof Ghast || entity instanceof Hoglin || entity instanceof Phantom || entity instanceof Slime)) {
+				continue;
+			}
+
+			if (living.getRemoveWhenFarAway()) {
+				entity.remove();
+			}
+		}
+	}
+}

--- a/plugins/simpleadminhacks-paper/src/main/resources/config.yml
+++ b/plugins/simpleadminhacks-paper/src/main/resources/config.yml
@@ -513,3 +513,5 @@ hacks:
   ToggleLamp:
     enabled: false
     cooldownTime: 100
+  DespawnFix:
+    enabled: true


### PR DESCRIPTION
At high despawn ranges, mobs might not have the chance to despawn before they are unloaded. This fix forcibly despawns the mob when it is unloaded.