### PR TITLE
Fix lag when loading the Name_layer_special group

### DIFF
--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
@@ -44,7 +44,7 @@ public class GroupManagerDao {
 				+ "inner join faction_id fi on fi.group_name = f.group_name "
 				+ "where f.group_name = ?";
 	private static final String getGroupIDs = "SELECT f.group_id, count(DISTINCT fm.member_name) AS sz FROM faction_id f "
-				+ "INNER JOIN faction_member fm ON f.group_id = fm.group_id WHERE f.group_name = ? GROUP BY f.group_id ORDER BY sz DESC";
+				+ "LEFT JOIN faction_member fm ON f.group_id = fm.group_id WHERE f.group_name = ? GROUP BY f.group_id ORDER BY sz DESC";
 	private static final String getGroupById = "select f.group_name, f.founder, f.password, f.discipline_flags, fi.group_id, f.last_timestamp " +
 				"from faction f "
 				+ "inner join faction_id fi on fi.group_id = ? "


### PR DESCRIPTION
When a group is deleted, it is "merged" into the Name_layer_special group by adding a redirection from the original group's ID to Name_layer_special's ID in the faction_id table.

Then, it deletes all members of the group. However, that breaks this statement which is an INNER JOIN, and only returns a row if there is a row in both tables.

Since the deleted group does not have any members, this query will not return the deleted group's ID, and that ID will not be associated with this group.

This caused a problem, because the deleted group's ID is still associated with all the reinforcements with that group. Whenever the group of a reinforcement is looked up, it will find the Name_layer_special group through the faction_id table's association. However, the lookup will not be cached, because the cache key is based on any IDs associated with the resultant group, and in this case, it does not include the deleted group's ID.

Therefore, with no caching, a database lookup will occur every time the group is needed, which will be performed on the main thread and can occur several times during, for instance, a single /cti or block break.

The fix involves using LEFT JOIN instead of INNER JOIN, so that the deleted group will still be returned even though it does not have any members.