### PR TITLE
Prevent Reinforcing In Combat

### DIFF
--- a/plugins/citadel-paper/build.gradle.kts
+++ b/plugins/citadel-paper/build.gradle.kts
@@ -9,5 +9,6 @@ dependencies {
 
 	compileOnly(project(":plugins:civmodcore-paper"))
 	compileOnly(project(":plugins:namelayer-paper"))
+	compileOnly(project(":plugins:combattagplus-paper"))
 	compileOnly("com.gmail.filoghost.holographicdisplays:holographicdisplays-api:2.4.9")
 }

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/Citadel.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/Citadel.java
@@ -1,8 +1,11 @@
 package vg.civcraft.mc.citadel;
 
 import java.util.logging.Logger;
+
+import net.minelink.ctplus.CombatTagPlus;
 import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.Plugin;
 import vg.civcraft.mc.citadel.listener.ActivityListener;
 import vg.civcraft.mc.citadel.activity.ActivityMap;
 import vg.civcraft.mc.citadel.command.CitadelCommandManager;
@@ -41,6 +44,7 @@ public class Citadel extends ACivMod {
 	private AcidManager acidManager;
 	private ReinforcementTypeManager typeManager;
 	private HologramManager holoManager;
+    private CombatTagPlus combatTagPlus;
 	private CitadelSettingManager settingManager;
 	private CitadelDAO dao;
 	private ActivityMap activityMap;
@@ -79,10 +83,14 @@ public class Citadel extends ACivMod {
 		return holoManager;
 	}
 
+	public CombatTagPlus getCombatTagPlus() {
+		return combatTagPlus;
+	}
+
 	public ActivityMap getActivityMap() {
 		return activityMap;
 	}
-	
+
 	CitadelDAO getDAO() {
 		return dao;
 	}
@@ -156,6 +164,11 @@ public class Citadel extends ACivMod {
 			else {
 				logger.info("HolographicDisplays is not loaded, no holograms available");
 			}});
+
+		Plugin combatTagPlusPlugin = Bukkit.getPluginManager().getPlugin("CombatTagPlus");
+		if(combatTagPlusPlugin != null) {
+			combatTagPlus = (CombatTagPlus) combatTagPlusPlugin;
+		}
 		commandManager = new CitadelCommandManager(this);
 		CitadelPermissionHandler.setup();
 		registerListeners();

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/CitadelConfigManager.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/CitadelConfigManager.java
@@ -48,6 +48,7 @@ public class CitadelConfigManager extends ConfigParser {
 	private double redstoneRange;
 
 	private boolean hangersInheritReinforcements;
+	private boolean blockReinforcingInCombat;
 
 	private int activityMapResolution;
 	private int activityMapRadius;
@@ -101,6 +102,10 @@ public class CitadelConfigManager extends ConfigParser {
 
 	public boolean doHangersInheritReinforcements() {
 		return hangersInheritReinforcements;
+	}
+
+	public boolean shouldBlockReinforcingInCombat() {
+		return blockReinforcingInCombat;
 	}
 
 	public Map<UUID, WorldBorderBuffers> getWorldBorderBuffers() {
@@ -171,6 +176,7 @@ public class CitadelConfigManager extends ConfigParser {
 		parseReinforcementTypes(config.getConfigurationSection("reinforcements"));
 		parseAcidTypes(config.getConfigurationSection("acids"));
 		hangersInheritReinforcements = config.getBoolean("hangers_inherit_reinforcement", false);
+		blockReinforcingInCombat = config.getBoolean("block_reinforcing_in_combat", false);
 
 		activityMapRadius = config.getInt("activity-map-radius", 1);
 		activityMapResolution = config.getInt("activity-map-resolution", 512);

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/CitadelUtility.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/CitadelUtility.java
@@ -5,6 +5,8 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.hover.content.Text;
+import net.minelink.ctplus.CombatTagPlus;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -197,6 +199,15 @@ public class CitadelUtility {
 			Citadel.getInstance().getStateManager().setState(player, null);
 			CitadelUtility.sendAndLog(player, ChatColor.RED,
 					"You have no items left to reinforce with " + type.getName(),
+					block.getLocation());
+			return true;
+		}
+		if (Bukkit.getPluginManager().getPlugin("CombatTagPlus") != null &&
+				Citadel.getInstance().getCombatTagPlus().getTagManager().isTagged(player.getUniqueId()) &&
+				Citadel.getInstance().getConfigManager().shouldBlockReinforcingInCombat()) {
+			Citadel.getInstance().getStateManager().setState(player, null);
+			CitadelUtility.sendAndLog(player, ChatColor.RED,
+					"You cannot reinforce in combat ",
 					block.getLocation());
 			return true;
 		}

--- a/plugins/citadel-paper/src/main/resources/config.yml
+++ b/plugins/citadel-paper/src/main/resources/config.yml
@@ -218,6 +218,9 @@ acidblock_material:
 # Determines whether hanging entities (such as Item Frames) can be protected by their host block
 hangers_inherit_reinforcement: false
 
+# Determines whether or not reinforcing should be allowed in combat (requires CombatTagPlus to function)
+block_reinforcing_in_combat: false
+
 # reinforcement_damageMultiplier is m where BlockDamage = 2 ^ (n/m) where n is equal to the number of days the group has been inactive
 reinforcement_damageMultiplier: 365
 database:

--- a/plugins/citadel-paper/src/main/resources/plugin.yml
+++ b/plugins/citadel-paper/src/main/resources/plugin.yml
@@ -16,6 +16,7 @@ depend:
 - CivModCore
 softdepend:
 - HolographicDisplays
+- CombatTagPlus
 description: Citadel allows you to make blocks difficult to break. When a block is reinforced, it must be broken many times before it is destroyed.
 api-version: 1.17
 permissions:


### PR DESCRIPTION
Cancels reinforcement if attempted while in combat. Cancels the same way as running out of reinforcement materials does.