### PR TITLE
Fix show next page

### DIFF
--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
@@ -82,7 +82,7 @@ public class MainGroupGUI extends AbstractGroupGUI {
 		}
 		ClickableInventory ci = new ClickableInventory(54, g.getName());
 		final List<Clickable> clicks = constructClickables();
-		if (clicks.size() < 45 * currentPage) {
+		if (clicks.size() < 36 * currentPage) {
 			// would show an empty page, so go to previous
 			currentPage--;
 			showScreen();


### PR DESCRIPTION
Currently when loading a group page it first checks whether this page would be empty or not, but does so assuming 5 instead of 4 rows of member slots (45 instead of 36 slots) are shown per page, therefore it can incorrectly decide to reload the prior page.