### PR TITLE
Fix show previous page

### DIFF
--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
@@ -107,6 +107,9 @@ public class MainGroupGUI extends AbstractGroupGUI {
 				}
 			};
 			ci.setSlot(baCl, 45);
+		} else {
+		// back to overview button
+			ci.setSlot(getSuperMenuClickable(), 45);
 		}
 		// next button
 		if ((36 * (currentPage + 1)) < clicks.size()) {
@@ -127,7 +130,6 @@ public class MainGroupGUI extends AbstractGroupGUI {
 
 		// options
 
-		ci.setSlot(getSuperMenuClickable(), 45);
 		ci.setSlot(createInheritedMemberToggle(), 46);
 		ci.setSlot(createInviteToggle(), 47);
 		ci.setSlot(setupMemberTypeToggle(PlayerType.MEMBERS, showMembers), 48);


### PR DESCRIPTION
'Go to previous page' button is set to slot 45 when currentPage > 0, conflicting with 'Return to overview' which is afterwards set to slot 45 in all cases thus the previous page button never shows up. Id guess intended was for the latter to only be available on the first page?