### PR TITLE
Fix null connection error in NameLayer 1.20

### DIFF
--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/listeners/AssociationListener.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/listeners/AssociationListener.java
@@ -58,10 +58,7 @@ public class AssociationListener implements Listener {
 		UUID uuid = event.getPlayer().getUniqueId();
 		associations.addPlayer(playername, uuid);
 		event.setJoinMessage(ChatColor.YELLOW + NameAPI.getCurrentName(uuid) + " joined the game");
-	}
 
-	@EventHandler(priority = EventPriority.LOWEST)
-	public void OnPlayerLogin(PlayerLoginEvent event) {
 		final Player player = event.getPlayer();
 		MojangNames.declareMojangName(player.getUniqueId(), player.getName());
 		String name = associations.getCurrentName(player.getUniqueId());
@@ -70,6 +67,7 @@ public class AssociationListener implements Listener {
 			associations.addPlayer(player.getName(), player.getUniqueId());
 			name = associations.getCurrentName(player.getUniqueId());
 		}
+
 
 		if (game != null)
 			game.setPlayerProfile(player, name);


### PR DESCRIPTION
`PlayerLoginEvent` is called before the connection is assigned, moving the `setPlayerProfile` call to the `PlayerJoinEvent` listener fixes this as by that point the connection has been assigned.