### PR TITLE
Add a toggle to enable/disable banned pearls in ep showall

### DIFF
--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/command/CmdShowAllPearls.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/command/CmdShowAllPearls.java
@@ -57,17 +57,20 @@ public class CmdShowAllPearls extends PearlCommand {
 	@Override
 	public void perform() {
 		final Player sender = player();
+		if (onCoolDown(sender)) return;
+		generateOpenPearlsMenu(sender);
+	}
 
+	private boolean onCoolDown(Player sender) {
 		final long now = System.currentTimeMillis();
 		final long previousUseTime = COOLDOWNS.compute(sender.getUniqueId(),
 				(uuid, value) -> value == null ? 0L : value); // This is better than getOrDefault()
 		if (previousUseTime > (now - COOLDOWN)) {
 			sender.sendMessage(ChatColor.RED + "You can't do that yet.");
-			return;
+			return true;
 		}
 		COOLDOWNS.put(sender.getUniqueId(), now);
-
-		generateOpenPearlsMenu(sender);
+		return false;
 	}
 
 	private void generateOpenPearlsMenu(Player sender) {
@@ -227,6 +230,7 @@ public class CmdShowAllPearls extends PearlCommand {
 		return new Clickable(item) {
 			@Override
 			public void clicked(final Player clicker) {
+				if (onCoolDown(clicker)) return;
 				bannedPearlToggle = !bannedPearlToggle;
 				clicker.sendMessage(Component.text()
 						.color(NamedTextColor.GREEN)


### PR DESCRIPTION
Added a button to `/ep showall` menu to toggle banned pearls and turned them off by default. Toggle shares cooldown with command as it essentially reruns the command each time it's clicked but with the filter on or off.

https://github.com/CivMC/Civ/assets/14056973/4b3cd5af-6b47-428a-b658-6775cddc3fe7

