### PR TITLE
Fix horse stats message double sending

### DIFF
--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/HorseStats.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/HorseStats.java
@@ -26,7 +26,6 @@ public class HorseStats extends SimpleHack<HorseStatsConfig> implements Listener
 
 	@EventHandler(priority = EventPriority.NORMAL)
 	public void onHorseStatCheck(PlayerInteractEntityEvent event) {
-		System.out.println("evt");
 		if (!config.isEnabled()) {
 			return;
 		}

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/HorseStats.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/HorseStats.java
@@ -14,6 +14,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
 public class HorseStats extends SimpleHack<HorseStatsConfig> implements Listener {
@@ -25,11 +26,15 @@ public class HorseStats extends SimpleHack<HorseStatsConfig> implements Listener
 
 	@EventHandler(priority = EventPriority.NORMAL)
 	public void onHorseStatCheck(PlayerInteractEntityEvent event) {
+		System.out.println("evt");
 		if (!config.isEnabled()) {
 			return;
 		}
 		ItemStack item = event.getPlayer().getInventory().getItemInMainHand();
 		if (!item.getType().equals(config.getHorseCheckerItem())) {
+			return;
+		}
+		if (event.getHand() == EquipmentSlot.OFF_HAND) {
 			return;
 		}
 		Entity entity = event.getRightClicked();


### PR DESCRIPTION
The `PlayerInteractEntityEvent` event fires twice, once for both of the players hands, so the message was displayed twice. Only occurs if the stats are checked whilst another player is riding the horse, but ignoring the offhand version of the event fixes it.