### PR TITLE
Don't heal dead entities with health potions

### DIFF
--- a/plugins/finale-paper/src/main/java/com/github/maxopoly/finale/listeners/PotionListener.java
+++ b/plugins/finale-paper/src/main/java/com/github/maxopoly/finale/listeners/PotionListener.java
@@ -101,14 +101,14 @@ public class PotionListener implements Listener {
 
 			modifiedHealth += intensity * multiplier * (healingEffect.getAmplifier() + 1)
 					* healthPerPotionLevel;
-			entity.setHealth(Math.min(maxHealth, modifiedHealth));
+			if (!entity.isDead()) entity.setHealth(Math.min(maxHealth, modifiedHealth));
 		}
 	}
 
 	@EventHandler
 	public void itemConsume(PlayerItemConsumeEvent e) {
 		PotionModification potMod = getModification(e.getItem());
-		if (potMod == null) {
+		if (potMod == null || e.getPlayer().isDead()) {
 			return;
 		}
 		PotionMeta potMeta = (PotionMeta) e.getItem().getItemMeta();
@@ -141,7 +141,7 @@ public class PotionListener implements Listener {
 						ent.addPotionEffect(potEffect, false);
 					};
 			for (LivingEntity ent : e.getAffectedEntities()) {
-				impact.accept(ent);
+				if (!ent.isDead()) impact.accept(ent);
 			}
 		});
 	}


### PR DESCRIPTION
Fixes what's known as a "pot glitch" where throwing a health potion at the right time can revive a dead player.

Duplicate of https://github.com/CivMC/Civ/pull/326 because I messed up and put that one on the main branch of my fork.