### PR TITLE
Allow interacting with chests and trapdoors if doing so would not actually open them

### DIFF
--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -231,6 +231,11 @@ public class BlockListener implements Listener {
 			return;
 		}
 
+		// Iron trapdoors and doors cannot be opened by right clicking on them
+		if (e.getClickedBlock().getType() == Material.IRON_TRAPDOOR || e.getClickedBlock().getType() == Material.IRON_DOOR) {
+			return;
+		}
+
 		if (e.getClickedBlock().getState() instanceof Container) {
 			if (!rein.hasPermission(player, CitadelPermissionHandler.getChests())) {
 				e.setCancelled(true);

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -222,21 +222,30 @@ public class BlockListener implements Listener {
 		if (rein == null) {
 			return;
 		}
+		Player player = e.getPlayer();
+
+		// Logic copied from ServerPlayerGameMode#useItemOn
+		// This will let the event happen if the player is not going to actually open/interact with the block
+		boolean flag = player.getInventory().getItemInMainHand().getType() != Material.AIR || player.getInventory().getItemInOffHand().getType() != Material.AIR;
+		if (player.isSneaking() && flag) {
+			return;
+		}
+
 		if (e.getClickedBlock().getState() instanceof Container) {
-			if (!rein.hasPermission(e.getPlayer(), CitadelPermissionHandler.getChests())) {
+			if (!rein.hasPermission(player, CitadelPermissionHandler.getChests())) {
 				e.setCancelled(true);
 				String msg = String.format("%s is locked with %s%s", e.getClickedBlock().getType().name(),
 						ChatColor.AQUA, rein.getType().getName());
-				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, msg, e.getClickedBlock().getLocation());
+				CitadelUtility.sendAndLog(player, ChatColor.RED, msg, e.getClickedBlock().getLocation());
 			}
 			return;
 		}
 		if (e.getClickedBlock().getBlockData() instanceof Openable) {
-			if (!rein.hasPermission(e.getPlayer(), CitadelPermissionHandler.getDoors())) {
+			if (!rein.hasPermission(player, CitadelPermissionHandler.getDoors())) {
 				e.setCancelled(true);
 				String msg = String.format("%s is locked with %s%s", e.getClickedBlock().getType().name(),
 						ChatColor.AQUA, rein.getType().getName());
-				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, msg, e.getClickedBlock().getLocation());
+				CitadelUtility.sendAndLog(player, ChatColor.RED, msg, e.getClickedBlock().getLocation());
 			}
 		}
 	}


### PR DESCRIPTION
Previously players were not able to use potions on top of these kinds of blocks or place blocks on top of them with shift right click. This change will allow that behaviour.