### PR TITLE
Fix NPE in CivChat

### DIFF
--- a/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/listeners/CivChat2Listener.java
+++ b/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/listeners/CivChat2Listener.java
@@ -76,7 +76,11 @@ public class CivChat2Listener implements Listener {
 				p.sendMessage(playerJoinEvent.getPlayer().getDisplayName() + ChatColor.YELLOW + " has joined the game");
 			}
 		}
-		
+
+		if (Bukkit.getPlayer(chatman.getChannel(playerJoinEvent.getPlayer())) == null) {
+			chatman.removeChannel(playerJoinEvent.getPlayer());
+		}
+
 		// Set current chat group in scoreboard
 		chatman.getScoreboardHUD().updateScoreboardHUD(playerJoinEvent.getPlayer());
 

--- a/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/utility/ScoreboardHUD.java
+++ b/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/utility/ScoreboardHUD.java
@@ -35,7 +35,7 @@ public class ScoreboardHUD {
 			DisplayLocationSetting locSetting = settingMan.getChatGroupLocation();
 			CivChat2Manager chatman = CivChat2.getInstance().getCivChat2Manager();
 			String text;
-			if (chatman.getChannel(p) != null ) {
+			if (chatman.getChannel(p) != null && Bukkit.getPlayer(chatman.getChannel(p)) != null) {
 				text = ChatColor.GOLD + "Messaging " + ChatColor.LIGHT_PURPLE + Bukkit.getPlayer(chatman.getChannel(p)).getName();
 			} else if (chatman.getGroupChatting(p) != null) {
 				text = ChatColor.GOLD + "Chat Group " + ChatColor.LIGHT_PURPLE + chatman.getGroupChatting(p).getName();


### PR DESCRIPTION
Due to the new changes with the scoreboard where it now updated when you log in, it might try and show you as messaging a player who is offline. This change will no longer show you as messaging players who are offline and will also automatically disable messaging them.