### PR TITLE
Fix portal hack not triggering

### DIFF
--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/PortalModifyHack.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/PortalModifyHack.java
@@ -1,5 +1,6 @@
 package com.programmerdan.minecraft.simpleadminhacks.hacks.basic;
 
+import com.destroystokyo.paper.event.server.ServerTickEndEvent;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
@@ -13,8 +14,10 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.event.player.PlayerPortalEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class PortalModifyHack extends BasicHack {
 
@@ -22,6 +25,8 @@ public class PortalModifyHack extends BasicHack {
 	private String targetWorld;
 	@AutoLoad
 	private String homeWorld;
+
+	private final Map<Player, Location> teleports = new HashMap<>();
 	
 	public PortalModifyHack(SimpleAdminHacks plugin, BasicHackConfig config) {
 		super(plugin, config);
@@ -52,10 +57,18 @@ public class PortalModifyHack extends BasicHack {
 				return;
 		}
 		event.setCancelled(true);
-		player.teleport(to, PlayerTeleportEvent.TeleportCause.END_PORTAL);
-		if (to.getWorld().getName().equals(targetWorld)) {
-			spawnExit(to);
+		teleports.put(player, to);
+	}
+
+	@EventHandler
+	public void onTick(ServerTickEndEvent event) {
+		for (Map.Entry<Player, Location> entry : teleports.entrySet()) {
+				entry.getKey().teleport(entry.getValue(), PlayerTeleportEvent.TeleportCause.END_PORTAL);
+				if (entry.getValue().getWorld().getName().equals(targetWorld)) {
+					spawnExit(entry.getValue());
+				}
 		}
+		teleports.clear();
 	}
 
 	private World getTargetWorld(Player player) {

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/PortalModifyHack.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/PortalModifyHack.java
@@ -4,6 +4,7 @@ import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
 import com.programmerdan.minecraft.simpleadminhacks.framework.autoload.AutoLoad;
+import io.papermc.paper.event.entity.EntityInsideBlockEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.HeightMap;
 import org.bukkit.Location;
@@ -27,10 +28,12 @@ public class PortalModifyHack extends BasicHack {
 	}
 
 	//We want to go last incase any plugins want to cancel our attempt
-	@EventHandler(priority = EventPriority.HIGHEST)
-	public void onPlayerEnterPortal(PlayerPortalEvent event) {
-		Player player = event.getPlayer();
-		if (event.getCause() != PlayerTeleportEvent.TeleportCause.END_PORTAL) {
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void onPlayerEnterPortal(EntityInsideBlockEvent event) {
+		if (!(event.getEntity() instanceof Player player)) {
+			return;
+		}
+		if (event.getBlock().getType() != Material.END_PORTAL) {
 			return;
 		}
 		World world = Bukkit.getWorld(targetWorld);
@@ -40,7 +43,7 @@ public class PortalModifyHack extends BasicHack {
 		Location to;
 		switch (getTargetWorld(player).getEnvironment()) {
 			case NETHER:
-				to = new Location(getTargetWorld(player), event.getFrom().getX(), 125, event.getFrom().getZ());
+				to = new Location(getTargetWorld(player), player.getLocation().getX(), 125, player.getLocation().getZ());
 				break;
 			case NORMAL:
 				to = getTargetWorld(player).getHighestBlockAt(player.getLocation(), HeightMap.WORLD_SURFACE).getLocation().toCenterLocation().add(0,1,0);
@@ -48,7 +51,8 @@ public class PortalModifyHack extends BasicHack {
 			default:
 				return;
 		}
-		event.setTo(to);
+		event.setCancelled(true);
+		player.teleport(to, PlayerTeleportEvent.TeleportCause.END_PORTAL);
 		if (to.getWorld().getName().equals(targetWorld)) {
 			spawnExit(to);
 		}


### PR DESCRIPTION
If you are falling really fast, you will be falling multiple blocks per second, and could possibly pass straight through an end portal. This fix changes the hack to use an event triggered earlier to detect if a player passes through an end portal.