### PR TITLE
Re-add standardised test output formatting

### DIFF
--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -1,4 +1,6 @@
 import io.papermc.paperweight.tasks.RemapJar
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import xyz.jpenilla.runpaper.task.RunServer
 
 subprojects {
@@ -20,6 +22,17 @@ subprojects {
 
     tasks.withType<ProcessResources> {
         filteringCharset = "UTF-8"
+    }
+
+    tasks.withType<Test> {
+        useJUnitPlatform()
+        testLogging {
+            events(*TestLogEvent.values())
+            exceptionFormat = TestExceptionFormat.FULL
+            showCauses = true
+            showExceptions = true
+            showStackTraces = true
+        }
     }
 
     configure<PublishingExtension> {


### PR DESCRIPTION
Re-adds [this change](https://github.com/CivMC/CivGradle/pull/2) to CivGradle. Each plugin will still need to include junit test dependencies as there doesn't seem to be a way to do so from the root `build.gradle.kts` without applying the `java-library` plugin to the root project.