### PR TITLE
Fix Factory Overflow

### DIFF
--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemMap.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemMap.java
@@ -520,8 +520,10 @@ public class ItemMap {
 			return false;
 		}
 		
+		ClonedInventory clonedInventory = ClonedInventory.cloneInventory(i);
+		
 		for(ItemStack itemStack : this.getItemStackRepresentation()) {
-			if (!ClonedInventory.cloneInventory(i).addItem(itemStack).isEmpty()) {
+			if (!clonedInventory.addItem(itemStack).isEmpty()) {
 				return false;
 			}
 		}

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemMap.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemMap.java
@@ -2,15 +2,6 @@ package vg.civcraft.mc.civmodcore.inventory.items;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.ByteTag;
 import net.minecraft.nbt.CompoundTag;
@@ -31,10 +22,20 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.inventory.meta.Repairable;
+import vg.civcraft.mc.civmodcore.inventory.ClonedInventory;
 import vg.civcraft.mc.civmodcore.nbt.NBTSerialization;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 import vg.civcraft.mc.civmodcore.utilities.MoreMath;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Allows the storage and comparison of item stacks while ignoring their maximum possible stack sizes. This offers
@@ -495,10 +496,10 @@ public class ItemMap {
 	}
 
 	/**
-	 * Checks whether this instance would completly fit into the given inventory
+	 * Checks whether this instance would completely fit into the given inventory
 	 *
 	 * @param i Inventory to check
-	 * @return True if this ItemMap's item representation would completly fit in the inventory, false if not
+	 * @return True if this ItemMap's item representation would completely fit in the inventory, false if not
 	 */
 	public boolean fitsIn(Inventory i) {
 		int size;
@@ -509,11 +510,22 @@ public class ItemMap {
 		}
 		ItemMap invCopy = new ItemMap();
 		for (ItemStack is : i.getStorageContents()) {
-			invCopy.addItemStack(is);
+			if (is == null) continue;
+			invCopy.addItemAmount(is, is.getAmount());
 		}
 		ItemMap instanceCopy = this.clone();
 		instanceCopy.merge(invCopy);
-		return instanceCopy.getItemStackRepresentation().size() <= size;
+		
+		if (!(instanceCopy.getItemStackRepresentation().size() <= size)) {
+			return false;
+		}
+		
+		for(ItemStack itemStack : this.getItemStackRepresentation()) {
+			if (!ClonedInventory.cloneInventory(i).addItem(itemStack).isEmpty()) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
@@ -5,8 +5,6 @@ import com.github.igotyou.FactoryMod.events.FactoryActivateEvent;
 import com.github.igotyou.FactoryMod.events.RecipeExecuteEvent;
 import com.github.igotyou.FactoryMod.interactionManager.IInteractionManager;
 import com.github.igotyou.FactoryMod.powerManager.FurnacePowerManager;
-import com.github.igotyou.FactoryMod.utility.Direction;
-import com.github.igotyou.FactoryMod.utility.IIOFInventoryProvider;
 import com.github.igotyou.FactoryMod.powerManager.IPowerManager;
 import com.github.igotyou.FactoryMod.recipes.IRecipe;
 import com.github.igotyou.FactoryMod.recipes.InputRecipe;
@@ -17,16 +15,10 @@ import com.github.igotyou.FactoryMod.recipes.Upgraderecipe;
 import com.github.igotyou.FactoryMod.repairManager.IRepairManager;
 import com.github.igotyou.FactoryMod.repairManager.PercentageHealthRepairManager;
 import com.github.igotyou.FactoryMod.structures.FurnCraftChestStructure;
+import com.github.igotyou.FactoryMod.utility.Direction;
+import com.github.igotyou.FactoryMod.utility.IIOFInventoryProvider;
 import com.github.igotyou.FactoryMod.utility.IOSelector;
 import com.github.igotyou.FactoryMod.utility.LoggingUtils;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Function;
-
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -45,6 +37,14 @@ import vg.civcraft.mc.citadel.model.Reinforcement;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
 
 /**
  * Represents a "classic" factory, which consists of a furnace as powersource, a
@@ -522,7 +522,6 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
 						deactivate();
 						return;
 					}
-					sendActivatorMessage(ChatColor.GOLD + currentRecipe.getName() + " in " + name + " completed");
 					if (currentRecipe instanceof Upgraderecipe || currentRecipe instanceof RecipeScalingUpgradeRecipe) {
 						// this if else might look a bit weird, but because
 						// upgrading changes the current recipe and a lot of
@@ -532,6 +531,7 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
 						return;
 					} else {
 						if (currentRecipe.applyEffect(getInputInventory(), getOutputInventory(), this)) {
+							sendActivatorMessage(ChatColor.GOLD + currentRecipe.getName() + " in " + name + " completed");
 							runCount.put(currentRecipe, runCount.get(currentRecipe) + 1);
 						} else {
 							sendActivatorMessage(ChatColor.RED + currentRecipe.getName() + " in " + name + " deactivated because it ran out of storage space");

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
@@ -335,7 +335,7 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
 		}
 
 		// Ensure the recipe effect can be applied
-		var effectFeasibility = currentRecipe.evaluateEffectFeasibility(getInputInventory(), getOutputInventory());
+		var effectFeasibility = currentRecipe.evaluateEffectFeasibility(getInputInventory(), getOutputInventory(), this);
 		if (!(effectFeasibility.isFeasible())) {
 			LoggingUtils.log(String.format("Skipping activation of recipe [%s], since the effect wasn't feasible.", currentRecipe.getName()));
 			if (p != null) {

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/DecompactingRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/DecompactingRecipe.java
@@ -1,11 +1,6 @@
 package com.github.igotyou.FactoryMod.recipes;
 
 import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Objects;
-
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
@@ -13,6 +8,11 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Used to decompact itemstacks, which means a single item with compacted lore
@@ -53,7 +53,7 @@ public class DecompactingRecipe extends InputRecipe {
 					ItemStack removeClone = it.clone();
 					removeClone.setAmount(1);
 					removeCompactLore(removeClone);
-					ItemMap toAdd = new ItemMap(removeClone);
+					ItemMap toAdd = new ItemMap();
 					toAdd.addItemAmount(removeClone, CompactingRecipe.getCompactStackSize(removeClone.getType()));
 					return toAdd;
 				})

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/DecompactingRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/DecompactingRecipe.java
@@ -45,7 +45,7 @@ public class DecompactingRecipe extends InputRecipe {
 	}
 
 	@Override
-	public EffectFeasibility evaluateEffectFeasibility(Inventory inputInv, Inventory outputInv) {
+	public EffectFeasibility evaluateEffectFeasibility(Inventory inputInv, Inventory outputInv, FurnCraftChestFactory fccf) {
 		boolean isFeasible = Arrays.stream(inputInv.getContents())
 				.filter(Objects::nonNull)
 				.filter(this::isDecompactable)

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/IRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/IRecipe.java
@@ -39,7 +39,7 @@ public interface IRecipe {
 	 * input/output inventories, or other custom recipe logic.
 	 * By default, this method returns a result indicating that the effect is always feasible to be applied.
 	 */
-	default public EffectFeasibility evaluateEffectFeasibility(Inventory inputInv, Inventory outputInv) {
+	default public EffectFeasibility evaluateEffectFeasibility(Inventory inputInv, Inventory outputInv, FurnCraftChestFactory fccf) {
 		return new EffectFeasibility(true, null);
 	}
 

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PlayerHeadRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PlayerHeadRecipe.java
@@ -1,11 +1,6 @@
 package com.github.igotyou.FactoryMod.recipes;
 
 import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
-
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -13,8 +8,14 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
+import vg.civcraft.mc.civmodcore.inventory.ClonedInventory;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 
 /***
  * Outputs a player head belonging to a random player who is connected to the server when the recipe is run
@@ -58,17 +59,23 @@ public class PlayerHeadRecipe extends InputRecipe {
 		if (players.isEmpty()) {
 			return false;
 		}
+		
 		if (toRemove.isContainedIn(inputInv)) {
+			Random rand = new Random();
+			Player player = players.get(rand.nextInt(players.size()));
+			ItemStack is = new ItemStack(Material.PLAYER_HEAD, 1);
+			
+			if (!ClonedInventory.cloneInventory(outputInv).addItem(is).isEmpty()) {
+				return false;
+			}
 			if (toRemove.removeSafelyFrom(inputInv)) {
-				Random rand = new Random();
-				Player player = players.get(rand.nextInt(players.size()));
-				ItemStack is = new ItemStack(Material.PLAYER_HEAD, 1);
 				SkullMeta im = (SkullMeta) is.getItemMeta();
 				im.setOwningPlayer(Bukkit.getOfflinePlayer(player.getUniqueId()));
 				im.setDisplayName(player.getDisplayName());
 				is.setItemMeta(im);
 				outputInv.addItem(is);
 			}
+			
 		}
 		logAfterRecipeRun(combo, fccf);
 		return true;

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintBookRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintBookRecipe.java
@@ -2,11 +2,6 @@ package com.github.igotyou.FactoryMod.recipes;
 
 import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
-
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-
 import net.minecraft.nbt.CompoundTag;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -16,10 +11,14 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventory.ClonedInventory;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 public class PrintBookRecipe extends PrintingPressRecipe {
 	private ItemMap printingPlate;
@@ -58,12 +57,16 @@ public class PrintBookRecipe extends PrintingPressRecipe {
 
 		ItemStack printingPlateStack = getPrintingPlateItemStack(inputInv, this.printingPlate);
 		ItemMap toRemove = this.input.clone();
-
+		
+		ItemStack book = createBook(printingPlateStack, this.outputAmount);
+		if (!ClonedInventory.cloneInventory(outputInv).addItem(book).isEmpty()) {
+			return false;
+		}
+		
 		if (printingPlateStack != null
 				&& toRemove.isContainedIn(inputInv)
 				&& toRemove.removeSafelyFrom(inputInv)
 		) {
-			ItemStack book = createBook(printingPlateStack, this.outputAmount);
 			book.editMeta(BookMeta.class, x -> x.setGeneration(getNextGeneration(x.getGeneration())));
 			outputInv.addItem(book);
 		}

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
@@ -6,11 +6,6 @@ package com.github.igotyou.FactoryMod.recipes;
 
 import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
@@ -18,8 +13,12 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventory.ClonedInventory;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class PrintNoteRecipe extends PrintBookRecipe {
 	private static class BookInfo {
@@ -69,14 +68,18 @@ public class PrintNoteRecipe extends PrintBookRecipe {
 
 		ItemStack printingPlateStack = getPrintingPlateItemStack(inputInv, getPrintingPlate());
 		ItemMap toRemove = this.input.clone();
-
+		
+		ItemStack paper = new ItemStack(Material.PAPER, getOutputAmount());
+		if (!ClonedInventory.cloneInventory(outputInv).addItem(paper).isEmpty()) {
+			return false;
+		}
+		
 		if (printingPlateStack != null
 				&& toRemove.isContainedIn(inputInv)
 				&& toRemove.removeSafelyFrom(inputInv)
 		) {
 			BookInfo info = getBookInfo(printingPlateStack);
-			ItemStack paper = new ItemStack(Material.PAPER, getOutputAmount());
-
+			
 			ItemMeta paperMeta = paper.getItemMeta();
 			paperMeta.setDisplayName(ChatColor.RESET + info.title);
 			paperMeta.setLore(info.lines);

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateJsonRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateJsonRecipe.java
@@ -8,8 +8,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
-import java.util.Arrays;
-import java.util.UUID;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
@@ -23,6 +21,9 @@ import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+
+import java.util.Arrays;
+import java.util.UUID;
 
 public class PrintingPlateJsonRecipe extends PrintingPlateRecipe {
 	/*
@@ -95,6 +96,10 @@ public class PrintingPlateJsonRecipe extends PrintingPlateRecipe {
 		ItemMap toRemove = input.clone();
 		ItemMap toAdd = output.clone();
 
+		if (!toAdd.fitsIn(outputInv)) {
+			return false;
+		}
+		
 		if (toRemove.isContainedIn(inputInv) && toRemove.removeSafelyFrom(inputInv)) {
 			for (ItemStack is : toAdd.getItemStackRepresentation()) {
 				is = addTags(serialNumber, is, bookNBT);

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateRecipe.java
@@ -7,10 +7,6 @@ package com.github.igotyou.FactoryMod.recipes;
 
 import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.UUID;
 import net.minecraft.nbt.CompoundTag;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -23,6 +19,11 @@ import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.BookMeta.Generation;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
 
 public class PrintingPlateRecipe extends PrintingPressRecipe {
 	public static final String itemName = "Printing Plate";
@@ -59,6 +60,10 @@ public class PrintingPlateRecipe extends PrintingPressRecipe {
 		ItemMap toRemove = input.clone();
 		ItemMap toAdd = output.clone();
 
+		if (!toAdd.fitsIn(outputInv)) {
+			return false;
+		}
+		
 		if (toRemove.isContainedIn(inputInv) && toRemove.removeSafelyFrom(inputInv)) {
 			for(ItemStack is: toAdd.getItemStackRepresentation()) {
 				is = addTags(serialNumber, is, CraftItemStack.asNMSCopy(book).getTag());

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/RandomOutputRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/RandomOutputRecipe.java
@@ -2,12 +2,6 @@ package com.github.igotyou.FactoryMod.recipes;
 
 import com.github.igotyou.FactoryMod.FactoryMod;
 import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Random;
-
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -15,6 +9,12 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Random;
 
 public class RandomOutputRecipe extends InputRecipe {
 	private Map<ItemMap, Double> outputs;
@@ -45,7 +45,17 @@ public class RandomOutputRecipe extends InputRecipe {
 			lowestChanceMap = displayOutput;
 		}
 	}
-
+	
+	@Override
+	public EffectFeasibility evaluateEffectFeasibility(Inventory inputInv, Inventory outputInv) {
+		boolean isFeasible = input.fitsIn(outputInv);
+		String reasonSnippet = isFeasible ? null : "it ran out of storage space";
+		return new EffectFeasibility(
+				isFeasible,
+				reasonSnippet
+		);
+	}
+	
 	@Override
 	public boolean applyEffect(Inventory inputInv, Inventory outputInv, FurnCraftChestFactory fccf) {
 		MultiInventoryWrapper combo = new MultiInventoryWrapper(inputInv, outputInv);
@@ -67,12 +77,17 @@ public class RandomOutputRecipe extends InputRecipe {
 			FactoryMod.getInstance().warning("Unable to find a random item to output. Recipe execution was cancelled," + fccf.getLogData());
 			return false;
 		}
-		if (toRemove.isContainedIn(inputInv)) {
-			if (toRemove.removeSafelyFrom(inputInv)) {
-				for(ItemStack is: toAdd.getItemStackRepresentation()) {
-					outputInv.addItem(is);
+		
+		if (toAdd.fitsIn(outputInv)) {
+			if (toRemove.isContainedIn(inputInv)) {
+				if (toRemove.removeSafelyFrom(inputInv)) {
+					for(ItemStack is: toAdd.getItemStackRepresentation()) {
+						outputInv.addItem(is);
+					}
 				}
 			}
+		} else {
+			return false;
 		}
 		logAfterRecipeRun(combo, fccf);
 		return true;


### PR DESCRIPTION
Fixes FactoryMod incorrectly believing that recipe output would fit in a chest because of some incorrect uses of `ItemMap`'s `fitsIn` and an issue with `fitsIn` itself.