### PR TITLE
Prune KeyedUtils

### DIFF
--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/EnchantUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/EnchantUtils.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.translation.Translatable;
 import org.apache.commons.collections4.CollectionUtils;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
@@ -22,7 +23,6 @@ import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.CivModCorePlugin;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
-import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 
 /**
  * Class of static utilities for Enchantments.
@@ -82,7 +82,7 @@ public final class EnchantUtils {
         }
         Enchantment enchantment;
         // From NamespacedKey
-        final var enchantmentKey = KeyedUtils.fromString(value);
+        final NamespacedKey enchantmentKey = NamespacedKey.fromString(value);
         if (enchantmentKey != null) {
             enchantment = Enchantment.getByKey(enchantmentKey);
             if (enchantment != null) {

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MoreTags.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MoreTags.java
@@ -14,6 +14,7 @@ import org.bukkit.Tag;
 import org.bukkit.block.data.Ageable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import vg.civcraft.mc.civmodcore.CivModCorePlugin;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 
@@ -293,7 +294,7 @@ public final class MoreTags {
         private final Set<T> values;
 
         private BetterTag(final String key, final Set<T> values) {
-            this.key = KeyedUtils.fromParts("civmodcore", key);
+            this.key = KeyedUtils.pluginKey(CivModCorePlugin.class, key);
             this.values = values;
         }
 

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/KeyedUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/KeyedUtils.java
@@ -1,73 +1,69 @@
 package vg.civcraft.mc.civmodcore.utilities;
 
-import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility class to make dealing with namespace keys easier.
  */
 public final class KeyedUtils {
-
     /**
-     * Converts a stringified namespaced-key back into a {@link NamespacedKey}.
+     * Convenience method that lets you construct a key namespaced to a plugin without needing a plugin instance.
      *
-     * @param key The stringified namespace-key, which MUST be formatted as {@code namespace:name}
-     * @return Returns a valid {@link NamespacedKey}, or null.
-     * @throws IllegalArgumentException Will throw if the stringified key fails a "[a-z0-9._-]+" check, or if the
-     *                                  total length is longer than 256.
+     * <pre><code>
+     * // If you used NamespacedKey as intended
+     * new NamespacedKey(ExamplePlugin.getInstance(), "example");
+     *
+     * // Using KeyedUtils.pluginKey()
+     * KeyedUtils.pluginKey(ExamplePlugin.class, "example");
+     * </code></pre>
      */
-    @Nullable
-    public static NamespacedKey fromString(@Nullable final String key) {
-        return key == null ? null : NamespacedKey.fromString(key);
+    public static <T extends JavaPlugin> @NotNull NamespacedKey pluginKey(
+        final @NotNull Class<T> pluginClass,
+        final @NotNull String key
+    ) {
+        return new NamespacedKey(JavaPlugin.getPlugin(pluginClass), key);
     }
 
     /**
-     * Converts a namespace and a key into a {@link NamespacedKey}.
-     *
-     * @param namespace The namespace name.
-     * @param key       The namespaced key.
-     * @return Returns a valid {@link NamespacedKey}, or null.
-     * @throws IllegalArgumentException Will throw if either part fails a "[a-z0-9._-]+" check, or if the total
-     *                                  combined length is longer than 256.
+     * Creates a new {@link NamespacedKey} for testing purposes.
      */
-    @SuppressWarnings("deprecation")
-    @NotNull
-    public static NamespacedKey fromParts(@NotNull final String namespace, @NotNull final String key) {
-        return new NamespacedKey(namespace, key);
-    }
-
-    /**
-     * Converts a {@link NamespacedKey} into a string.
-     *
-     * @param key The {@link NamespacedKey} to convert.
-     * @return Returns the stringified {@link NamespacedKey}, or null.
-     */
-    @Nullable
-    public static String getString(@Nullable final NamespacedKey key) {
-        return key == null ? null : key.toString();
-    }
-
-    /**
-     * Retrieves a {@link Keyed}'s {@link NamespacedKey} and converts it to a string.
-     *
-     * @param keyed The {@link Keyed} instance.
-     * @return Returns the stringified {@link Keyed}'s {@link NamespacedKey}, or null.
-     */
-    @Nullable
-    public static String getString(@Nullable final Keyed keyed) {
-        return keyed == null ? null : getString(keyed.getKey());
-    }
-
-    /**
-     * @param key The namespaced-key.
-     * @return Returns a new {@link NamespacedKey} for testing purposes.
-     */
-    @SuppressWarnings("deprecation")
-    @NotNull
-    public static NamespacedKey testKey(@NotNull final String key) {
+    public static @NotNull NamespacedKey testKey(
+        final @NotNull String key
+    ) {
         return new NamespacedKey("test", key);
     }
 
+    /**
+     * Creates a <a href="https://dictionary.cambridge.org/dictionary/english/ditto">ditto</a> key, primarily for child
+     * keys within {@link org.bukkit.persistence.PersistentDataContainer PersistentDataContainers}.
+     *
+     * <pre><code>
+     * // If you used PDCs as intended
+     * {
+     *     "CivModCore:players": [
+     *         {
+     *             "CivModCore:name": "Example",
+     *             "CivModCore:uuid": "61629d9c-c2a1-4379-b98e-4b538c6628c5"
+     *         }
+     *     ]
+     * }
+     *
+     * // Using ditto keys
+     * {
+     *     "CivModCore:players": [
+     *         {
+     *             ".:name": "Example",
+     *             ".:uuid": "61629d9c-c2a1-4379-b98e-4b538c6628c5"
+     *         }
+     *     ]
+     * }
+     * </code></pre>
+     */
+    public static @NotNull NamespacedKey dittoKey(
+        final @NotNull String key
+    ) {
+        return new NamespacedKey(".", key);
+    }
 }

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantModifier.java
@@ -34,7 +34,6 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.EnchantUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
-import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 import vg.civcraft.mc.civmodcore.utilities.MoreMapUtils;
 
 @CommandAlias(SetCommand.ALIAS)
@@ -91,8 +90,7 @@ public final class EnchantModifier extends ModifierData {
     public void toNBT(@NotNull final NBTCompound nbt) {
         nbt.setCompound(REQUIRED_KEY, NBTEncodings.encodeLeveledEnchants(getRequiredEnchants()));
         nbt.setStringArray(EXCLUDED_KEY, getExcludedEnchants().stream()
-            .map(KeyedUtils::getString)
-            .filter(Objects::nonNull)
+            .map((entry) -> entry.getKey().asString())
             .toArray(String[]::new));
         nbt.setBoolean(UNLISTED_KEY, isAllowingUnlistedEnchants());
     }

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/NBTEncodings.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/NBTEncodings.java
@@ -10,7 +10,6 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionType;
 import vg.civcraft.mc.civmodcore.inventory.items.EnchantUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
-import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 import vg.civcraft.mc.civmodcore.utilities.MoreMapUtils;
 
 public final class NBTEncodings {
@@ -34,7 +33,7 @@ public final class NBTEncodings {
             if (!MoreMapUtils.validEntry(entry)) {
                 continue;
             }
-            nbt.setInt(KeyedUtils.getString(entry.getKey()), entry.getValue());
+            nbt.setInt(entry.getKey().getKey().asString(), entry.getValue());
         }
         return nbt;
     }

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/Utilities.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/Utilities.java
@@ -28,7 +28,6 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionType;
 import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.InventoryUtils;
-import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 import vg.civcraft.mc.civmodcore.utilities.NullUtils;
 import vg.civcraft.mc.civmodcore.world.WorldUtils;
 
@@ -176,7 +175,7 @@ public final class Utilities {
         }
         return "[" +
             leveledEnchants.entrySet().stream()
-                .map(entry -> KeyedUtils.getString(entry.getKey()) + ":" + entry.getValue())
+                .map((entry) -> entry.getKey().getKey().asString() + ":" + entry.getValue())
                 .collect(Collectors.joining(",")) +
             "]";
     }
@@ -187,7 +186,7 @@ public final class Utilities {
         }
         return "[" +
             enchants.stream()
-                .map(entry -> KeyedUtils.getString(entry.getKey()))
+                .map((entry) -> entry.getKey().asString())
                 .collect(Collectors.joining(",")) +
             "]";
     }


### PR DESCRIPTION
Removed fromParts() in favour of pluginKey(), as the NamespacedKey parts constructor [was de-deprecated](https://github.com/PaperMC/Paper/issues/7753).