### PR TITLE
Refactor /ignorelist command

### DIFF
--- a/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/commands/IgnoreList.java
+++ b/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/commands/IgnoreList.java
@@ -3,59 +3,83 @@ package vg.civcraft.mc.civchat2.commands;
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.Description;
-import java.util.List;
-import java.util.UUID;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
-import vg.civcraft.mc.civchat2.ChatStrings;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civchat2.CivChat2;
 import vg.civcraft.mc.civchat2.database.CivChatDAO;
 import vg.civcraft.mc.namelayer.NameAPI;
 
-public class IgnoreList extends BaseCommand {
-
+public final class IgnoreList extends BaseCommand {
 	@CommandAlias("ignorelist")
 	@Description("Lists the players and groups you are ignoring")
-	public void execute(Player player) {
-		CivChatDAO db = CivChat2.getInstance().getDatabaseManager();
-		List<UUID> players = db.getIgnoredPlayers(player.getUniqueId());
-		List<String> groups = db.getIgnoredGroups(player.getUniqueId());
+	private void execute(
+		final @NotNull Player sender
+	) {
+		final CivChatDAO db = CivChat2.getInstance().getDatabaseManager();
 
-		// No players ignored
-		if (players == null || players.isEmpty()) {
-			player.sendMessage(ChatStrings.chatNotIgnoringAnyPlayers);
-		} else {
-			StringBuilder sb = new StringBuilder();
-			sb.append("<a>Ignored Players: \n<n>");
-			for (UUID playerUUID : players) {
-				String playerName = NameAPI.getCurrentName(playerUUID);
-				if (playerName != null) {
-					sb.append(playerName);
-					sb.append(", ");
-				}
-			}
-			String msg = sb.toString();
-			if (msg.endsWith(", ")) {
-				msg = msg.substring(0, msg.length() - 2);
-			}
-			player.sendMessage(msg);
-		}
+		// Ignored players
+		sender.sendMessage(
+			Component.text()
+				.content("Ignored players: [")
+				.append(
+					db.getIgnoredPlayers(sender.getUniqueId())
+						.stream()
+						.map(NameAPI::getCurrentName)
+						.filter(Objects::nonNull)
+						.flatMap(commaSeparatedClickableNames("/ignore %s"))
+						.toList()
+				)
+				.append(Component.text("]"))
+		);
 
-		// No groups ignored
-		if (groups == null || groups.isEmpty()) {
-			player.sendMessage(ChatStrings.chatNotIgnoringAnyGroups);
-			return;
-		} else {
-			StringBuilder sb = new StringBuilder();
-			sb.append("<a>Ignored Groups: \n<n>");
-			for (String s : groups) {
-				sb.append(s);
-				sb.append(", ");
+		// Ignored groups
+		sender.sendMessage(
+			Component.text()
+				.content("Ignored groups: [")
+				.append(
+					db.getIgnoredGroups(sender.getUniqueId())
+						.stream()
+						.flatMap(commaSeparatedClickableNames("/ignoregroup %s"))
+						.toList()
+				)
+				.append(Component.text("]"))
+		);
+	}
+
+	private static @NotNull Function<String, Stream<Component>> commaSeparatedClickableNames(
+		final @NotNull String formattedCommand
+	) {
+		final var hasPreviousName = new AtomicBoolean(false);
+		return (name) -> {
+			final Component clickableName = Component.text()
+				.content(name)
+				.color(NamedTextColor.YELLOW)
+				.decoration(TextDecoration.UNDERLINED, TextDecoration.State.TRUE)
+				.clickEvent(ClickEvent.clickEvent(
+					ClickEvent.Action.COPY_TO_CLIPBOARD,
+					formattedCommand.formatted(name)
+				))
+				.hoverEvent(HoverEvent.showText(Component.text("Click to copy un-ignore command")))
+				.build();
+			if (hasPreviousName.get()) {
+				return Stream.of(
+					Component.text(", "),
+					clickableName
+				);
 			}
-			String msg = sb.toString();
-			if (msg.endsWith(", ")) {
-				msg = msg.substring(0, msg.length() - 2);
+			else {
+				hasPreviousName.set(true);
+				return Stream.of(clickableName);
 			}
-			player.sendMessage(msg);
-		}
+		};
 	}
 }


### PR DESCRIPTION
Refactors `/ignorelist` to use Kyori components. Each ignored player/group is underlined and clickable and will unobtrusively copy the un-ignore command to the clipboard.

Before:
![image](https://github.com/CivMC/Civ/assets/52572989/fc2f17d7-2a35-4262-aedb-02f184ab08a0)

After:
![image](https://github.com/CivMC/Civ/assets/52572989/a3073f24-75f6-40f7-9da7-c5b4f9acffea)
