### PR TITLE
Revert "Discard entities before adding NPCs"

### DIFF
--- a/plugins/combattagplus-paper/src/main/java/net/minelink/ctplus/nms/NpcPlayer.java
+++ b/plugins/combattagplus-paper/src/main/java/net/minelink/ctplus/nms/NpcPlayer.java
@@ -33,7 +33,7 @@ public class NpcPlayer extends ServerPlayer {
     public static NpcPlayer valueOf(Player player) {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         ServerLevel worldServer = ((CraftWorld) player.getWorld()).getHandle();
-        GameProfile gameProfile = new GameProfile(player.getUniqueId(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
         ClientInformation clientInformation = ((CraftPlayer) player).getHandle().clientInformation();
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {

--- a/plugins/combattagplus-paper/src/main/java/net/minelink/ctplus/nms/NpcPlayerHelperImpl.java
+++ b/plugins/combattagplus-paper/src/main/java/net/minelink/ctplus/nms/NpcPlayerHelperImpl.java
@@ -12,7 +12,6 @@ import net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.food.FoodData;
 import net.minecraft.world.item.ItemStack;
@@ -51,12 +50,7 @@ public class NpcPlayerHelperImpl implements NpcPlayerHelper {
             serverPlayer.connection.send(packet);
         }
 
-        Entity oldPlayer = worldServer.getEntity(player.getUniqueId());
-
-        if (oldPlayer != null) {
-            oldPlayer.remove(Entity.RemovalReason.DISCARDED);
-            worldServer.addFreshEntity(npcPlayer);
-        }
+        worldServer.addFreshEntity(npcPlayer);
 
         return npcPlayer.getBukkitEntity();
     }


### PR DESCRIPTION
This reverts commit 5d2151f1cd458b66db140586924c28cb20cb698d, from PR https://github.com/CivMC/CombatTagPlus/pull/21.

This fixes players losing their bed position as well as players losing their crafting recipes and xp (https://github.com/CivMC/Civ/issues/93), because the fact that the UUID is the same, combined with https://github.com/CivMC/Civ/blob/f525b7afeb0fa63e4cef3e48c3ec1d7dc790fc5d/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java#L303, causes an interaction where the player's saved data is overriden with the NPC's data, which has *most* things copied but not the bed location. This change seems pretty broken, and was only applied recently with the 1.20 update, so I decided to roll it back until we implement a fix for everything.

Alternatively, we could make sure we are copying all of the data to the NPC, but since this has caused ~two~ three (https://github.com/CivMC/Civ/issues/93) independent issues already, it may cause more, and I think the safest option is to roll it back.