### PR TITLE
Defer paper version to libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+paper = "1.21.1-R0.1-SNAPSHOT"
+
+[libraries]
+paperapi = { group = "io.papermc.paper", name = "paper-api", version.ref = "paper" }

--- a/plugins/banstick-paper/build.gradle.kts
+++ b/plugins/banstick-paper/build.gradle.kts
@@ -7,7 +7,7 @@ version = "2.0.1"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/bastion-paper/build.gradle.kts
+++ b/plugins/bastion-paper/build.gradle.kts
@@ -7,6 +7,7 @@ version = "3.0.1"
 dependencies {
     paperweight {
         paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/castlegates-paper/build.gradle.kts
+++ b/plugins/castlegates-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "2.0.2"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/citadel-paper/build.gradle.kts
+++ b/plugins/citadel-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "5.2.4"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/civchat2-paper/build.gradle.kts
+++ b/plugins/civchat2-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "2.2.2"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/civduties-paper/build.gradle.kts
+++ b/plugins/civduties-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "1.5.0-SNAPSHOT"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/civmodcore-paper/build.gradle.kts
+++ b/plugins/civmodcore-paper/build.gradle.kts
@@ -8,7 +8,7 @@ version = "3.0.6"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     api("co.aikar:acf-bukkit:0.5.1-SNAPSHOT")

--- a/plugins/civspy-paper/build.gradle.kts
+++ b/plugins/civspy-paper/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     implementation(project(":plugins:civspy-api"))
 
     paperweight {
-        paperDevBundle("1.18.2-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 }
 

--- a/plugins/combattagplus-paper/build.gradle.kts
+++ b/plugins/combattagplus-paper/build.gradle.kts
@@ -7,7 +7,7 @@ version = "2.0.1"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly("com.github.TownyAdvanced:towny:0.100.3.0")

--- a/plugins/donum-paper/build.gradle.kts
+++ b/plugins/donum-paper/build.gradle.kts
@@ -1,7 +1,7 @@
 version = "2.0.0"
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
+    compileOnly(libs.paperapi)
 
     compileOnly(project(":plugins:civmodcore-paper"))
     compileOnly(project(":plugins:namelayer-paper"))

--- a/plugins/essenceglue-paper/build.gradle.kts
+++ b/plugins/essenceglue-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "2.0.0-SNAPSHOT"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/exilepearl-paper/build.gradle.kts
+++ b/plugins/exilepearl-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "2.1.6"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/factorymod-paper/build.gradle.kts
+++ b/plugins/factorymod-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "3.1.0"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/finale-paper/build.gradle.kts
+++ b/plugins/finale-paper/build.gradle.kts
@@ -10,7 +10,7 @@ version = "2.1.0"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/hiddenore-paper/build.gradle.kts
+++ b/plugins/hiddenore-paper/build.gradle.kts
@@ -6,6 +6,6 @@ version = "2.0.0-SNAPSHOT"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 }

--- a/plugins/itemexchange-paper/build.gradle.kts
+++ b/plugins/itemexchange-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "2.0.2"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/jukealert-paper/build.gradle.kts
+++ b/plugins/jukealert-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "3.0.8"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/kirabukkitgateway-paper/build.gradle.kts
+++ b/plugins/kirabukkitgateway-paper/build.gradle.kts
@@ -7,7 +7,7 @@ version = "2.0.3"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     api("com.rabbitmq:amqp-client:5.17.1")

--- a/plugins/namecolors-paper/build.gradle.kts
+++ b/plugins/namecolors-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "2.0.0-SNAPSHOT"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/namelayer-paper/build.gradle.kts
+++ b/plugins/namelayer-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "3.0.6"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/railswitch-paper/build.gradle.kts
+++ b/plugins/railswitch-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "2.0.0-SNAPSHOT"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/randomspawn-paper/build.gradle.kts
+++ b/plugins/randomspawn-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "3.0.4"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/realisticbiomes-paper/build.gradle.kts
+++ b/plugins/realisticbiomes-paper/build.gradle.kts
@@ -7,7 +7,7 @@ version = "3.2.3"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))

--- a/plugins/simpleadminhacks-paper/build.gradle.kts
+++ b/plugins/simpleadminhacks-paper/build.gradle.kts
@@ -6,7 +6,7 @@ version = "2.3.2"
 
 dependencies {
     paperweight {
-        paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+        paperDevBundle(libs.versions.paper)
     }
 
     compileOnly(project(":plugins:civmodcore-paper"))


### PR DESCRIPTION
This means not having to change a billion `"1.21.1-R0.1-SNAPSHOT"` whenever Civ updates versions, but also means that a plugin won't be accidentally left behind, like in the case of `civspy-paper`, which was left on 1.18.2.