### PR TITLE
Bandaid fix nbt matching issues

### DIFF
--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/ItemMetaConverterHack.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/ItemMetaConverterHack.java
@@ -4,11 +4,16 @@ import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
 import net.kyori.adventure.text.Component;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.inventory.ItemStack;
+import org.w3c.dom.Text;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
+
+import java.util.List;
 
 public class ItemMetaConverterHack extends BasicHack {
 
@@ -38,9 +43,10 @@ public class ItemMetaConverterHack extends BasicHack {
 		boolean displayNameWasChanged = false;
 		if (meta.hasDisplayName()) {
 			final var currentDisplayName = meta.displayName();
+
 			assert currentDisplayName != null;
 			if (!ChatUtils.isBaseComponent(currentDisplayName)) {
-				meta.displayName(Component.text().append(currentDisplayName).build());
+				meta.displayName(currentDisplayName.compact());
 				displayNameWasChanged = true;
 			}
 		}
@@ -51,7 +57,7 @@ public class ItemMetaConverterHack extends BasicHack {
 			for (int i = 0, l = currentLore.size(); i < l; i++) {
 				final var loreLine = currentLore.get(i);
 				if (!ChatUtils.isBaseComponent(loreLine)) {
-					currentLore.set(i, Component.text().append(loreLine).build());
+					currentLore.set(i, Component.empty().append(loreLine.compact()));
 					loreWasChanged = true;
 				}
 			}
@@ -63,5 +69,4 @@ public class ItemMetaConverterHack extends BasicHack {
 			item.setItemMeta(meta);
 		}
 	}
-
 }

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/ItemMetaConverterHack.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/ItemMetaConverterHack.java
@@ -4,16 +4,11 @@ import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
 import net.kyori.adventure.text.Component;
-import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.inventory.ItemStack;
-import org.w3c.dom.Text;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
-
-import java.util.List;
 
 public class ItemMetaConverterHack extends BasicHack {
 


### PR DESCRIPTION
Should fix issues impacting stacking and factory use of items like essence, fossils, and compacted items. See the video below for how to trigger the update. Re-logging is equivalent to a server restart, so any inventories opened before a restart will have their contents fully converted post-restart. 

I'm working on a proper fix that will happen in "real time" but for now this will at least make the items useable again (I think! This issue has been a real headache to deal with).

Addresses #510 

[1280x720.webm](https://github.com/CivMC/Civ/assets/63616270/36407aee-0fbd-4f0f-9696-93a57882ac93)
