### PR TITLE
Increase MaxPowerTransfers

### DIFF
--- a/ansible/files/paper-config/plugins/CastleGates/config.yml
+++ b/ansible/files/paper-config/plugins/CastleGates/config.yml
@@ -7,7 +7,7 @@ Database:
 Settings:
   AllowAutoCreate: true
   InteractWithSnitches: true
-  MaxPowerTransfers: 8
+  MaxPowerTransfers: 32
   MaxBridgeLength: 16
   PlayerStateResetInSeconds: 300
   SwitchTimeout: 1000


### PR DESCRIPTION
This fixes the issue noted [here](https://discord.com/channels/912074050086502470/952314940176363570/1259737460020350986). 

32 is a relatively arbitrary number that should allow castlegates of reasonable size to function when laid out in the fashion seen in the linked screenshots, if there's a reason it was set so low/could go higher I'm open to suggestions.