### PR TITLE
Bump entity render distances to default settings

### DIFF
--- a/ansible/files/paper-config/spigot.yml
+++ b/ansible/files/paper-config/spigot.yml
@@ -103,8 +103,8 @@ world-settings:
       players: 160
       animals: 32
       monsters: 64
-      misc: 16
-      other: 16
+      misc: 32
+      other: 64
     ticks-per:
       hopper-transfer: 16
       hopper-check: 8


### PR DESCRIPTION
This should fix arrows and such disappearing. It shouldn't really impact lag except maybe client-side in Altepetl but they had it comnig.