### PR TITLE
Switch from jsr305 to Jetbrains Annotations

### DIFF
--- a/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/data/BSBan.java
+++ b/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/data/BSBan.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * BSBan object, wraps an actual ban.
@@ -144,7 +144,7 @@ public final class BSBan {
      *
      * @param banEndTo the time to end the ban.
      */
-    public void setBanEndTime(@Nonnull Date banEndTo) {
+    public void setBanEndTime(@NotNull Date banEndTo) {
         setBanEndTime(new Timestamp(banEndTo.getTime()));
     }
 
@@ -153,7 +153,7 @@ public final class BSBan {
      *
      * @param banEndTo the time to end the ban.
      */
-    public void setBanEndTime(@Nonnull Timestamp banEndTo) {
+    public void setBanEndTime(@NotNull Timestamp banEndTo) {
         this.banEnd = banEndTo;
         this.dirty = true;
         dirtyBans.offer(new WeakReference<BSBan>(this));

--- a/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/data/BSSession.java
+++ b/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/data/BSSession.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a single playtime of a player.
@@ -70,7 +70,7 @@ public final class BSSession {
      *
      * @param leaveTime the departure / end time of the session.
      */
-    public void setLeaveTime(@Nonnull Date leaveTime) {
+    public void setLeaveTime(@NotNull Date leaveTime) {
         setLeaveTime(new Timestamp(leaveTime.getTime()));
     }
 
@@ -79,7 +79,7 @@ public final class BSSession {
      *
      * @param leaveTime the departure / end time of the session.
      */
-    public void setLeaveTime(@Nonnull Timestamp leaveTime) {
+    public void setLeaveTime(@NotNull Timestamp leaveTime) {
         this.leaveTime = leaveTime;
         this.dirty = true;
         dirtySessions.offer(new WeakReference<BSSession>(this));

--- a/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/data/BSShare.java
+++ b/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/data/BSShare.java
@@ -17,8 +17,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import javax.annotation.Nonnull;
 import org.bukkit.ChatColor;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Defines an explicit 1 to 1 relationship between two players
@@ -76,7 +76,7 @@ public final class BSShare {
      *
      * @param pardonTime The Java Date to pardon on.
      */
-    public void setPardonTime(@Nonnull Date pardonTime) {
+    public void setPardonTime(@NotNull Date pardonTime) {
         setPardonTime(new Timestamp(pardonTime.getTime()));
     }
 
@@ -85,7 +85,7 @@ public final class BSShare {
      *
      * @param pardonTime The SQL Date to pardon on.
      */
-    public void setPardonTime(@Nonnull Timestamp pardonTime) {
+    public void setPardonTime(@NotNull Timestamp pardonTime) {
         this.pardonTime = pardonTime;
         this.dirty = true;
         dirtyShares.offer(new WeakReference<BSShare>(this));

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/command/CitadelCommandManager.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/command/CitadelCommandManager.java
@@ -2,8 +2,8 @@ package vg.civcraft.mc.citadel.command;
 
 import co.aikar.commands.BukkitCommandCompletionContext;
 import co.aikar.commands.CommandCompletions;
-import javax.annotation.Nonnull;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.commands.CommandManager;
 import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 
@@ -33,7 +33,7 @@ public class CitadelCommandManager extends CommandManager {
     }
 
     @Override
-    public void registerCompletions(@Nonnull CommandCompletions<BukkitCommandCompletionContext> completions) {
+    public void registerCompletions(@NotNull CommandCompletions<BukkitCommandCompletionContext> completions) {
         super.registerCompletions(completions);
         completions.registerCompletion("CT_Groups", (context) -> GroupTabCompleter.complete(context.getInput(), null, context.getPlayer()));
     }

--- a/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/commands/CivChatCommandManager.java
+++ b/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/commands/CivChatCommandManager.java
@@ -2,8 +2,8 @@ package vg.civcraft.mc.civchat2.commands;
 
 import co.aikar.commands.BukkitCommandCompletionContext;
 import co.aikar.commands.CommandCompletions;
-import javax.annotation.Nonnull;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.commands.CommandManager;
 import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 
@@ -31,7 +31,7 @@ public class CivChatCommandManager extends CommandManager {
     }
 
     @Override
-    public void registerCompletions(@Nonnull CommandCompletions<BukkitCommandCompletionContext> completions) {
+    public void registerCompletions(@NotNull CommandCompletions<BukkitCommandCompletionContext> completions) {
         super.registerCompletions(completions);
         completions.registerCompletion("CC_Groups", (context) -> GroupTabCompleter
             .complete(context.getInput(), null, context.getPlayer()));

--- a/plugins/civmodcore-paper/build.gradle.kts
+++ b/plugins/civmodcore-paper/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     api("co.aikar:taskchain-bukkit:3.7.2")
     api("org.apache.commons:commons-lang3:3.12.0")
     api("org.apache.commons:commons-collections4:4.4")
-    api("com.google.code.findbugs:jsr305:3.0.2")
 
     compileOnly("it.unimi.dsi:fastutil:8.5.8")
 

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/ACivMod.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/ACivMod.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
-import javax.annotation.Nonnull;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
@@ -15,6 +14,7 @@ import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class ACivMod extends JavaPlugin {
 
@@ -59,7 +59,7 @@ public abstract class ACivMod extends JavaPlugin {
      *
      * @param listener The listener class to register.
      */
-    public void registerListener(@Nonnull final Listener listener) {
+    public void registerListener(@NotNull final Listener listener) {
         getServer().getPluginManager().registerEvents(
             Objects.requireNonNull(listener, "Cannot register a listener if it's null, you dummy"), this);
     }
@@ -70,7 +70,7 @@ public abstract class ACivMod extends JavaPlugin {
      *
      * @param clazz The serializable class to register and automatically unregister upon disable.
      */
-    public void registerConfigClass(@Nonnull final Class<? extends ConfigurationSerializable> clazz) {
+    public void registerConfigClass(@NotNull final Class<? extends ConfigurationSerializable> clazz) {
         Objects.requireNonNull(clazz, "Cannot register a config class if it's null, you dummy");
         ConfigurationSerialization.registerClass(clazz);
         this.configClasses.add(clazz);
@@ -91,7 +91,7 @@ public abstract class ACivMod extends JavaPlugin {
      * @param path The path of the file relative to the data folder.
      * @return Returns a file instance of the generated path.
      */
-    public File getDataFile(@Nonnull final String path) {
+    public File getDataFile(@NotNull final String path) {
         return new File(getDataFolder(), Objects.requireNonNull(path));
     }
 
@@ -100,7 +100,7 @@ public abstract class ACivMod extends JavaPlugin {
      *
      * @param path The path to the default resource <i>AND</i> the data file.
      */
-    public void saveDefaultResource(@Nonnull final String path) {
+    public void saveDefaultResource(@NotNull final String path) {
         if (!getDataFile(path).exists()) {
             saveResource(path, false);
         }
@@ -112,8 +112,8 @@ public abstract class ACivMod extends JavaPlugin {
      * @param defaultPath The path of the file within the plugin's jar.
      * @param dataPath The path the file should take within the plugin's data folder.
      */
-//	public void saveDefaultResourceAs(@Nonnull String defaultPath,
-//									  @Nonnull String dataPath) {
+//	public void saveDefaultResourceAs(@NotNull String defaultPath,
+//									  @NotNull String dataPath) {
 //		if (getDataFile(defaultPath).exists()) {
 //			return;
 //		}

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/CivModCoreConfig.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/CivModCoreConfig.java
@@ -1,8 +1,8 @@
 package vg.civcraft.mc.civmodcore;
 
-import javax.annotation.Nonnull;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.config.ConfigParser;
 import vg.civcraft.mc.civmodcore.dao.DatabaseCredentials;
 
@@ -25,14 +25,14 @@ public final class CivModCoreConfig extends ConfigParser {
     private int chunkLoadingThreads;
     private static final int DEFAULT_CHUNK_LOADING_THREADS = 1;
 
-    CivModCoreConfig(@Nonnull final CivModCorePlugin plugin) {
+    CivModCoreConfig(@NotNull final CivModCorePlugin plugin) {
         super(plugin);
         Objects.requireNonNull(plugin);
         reset();
     }
 
     @Override
-    protected boolean parseInternal(@Nonnull final ConfigurationSection config) {
+    protected boolean parseInternal(@NotNull final ConfigurationSection config) {
         this.databaseCredentials = config.getObject("database",
             DatabaseCredentials.class, DEFAULT_DATABASE_CREDENTIALS);
         this.scoreboardHeader = ChatColor.translateAlternateColorCodes('&',

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/ChatUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/ChatUtils.java
@@ -5,8 +5,6 @@ import java.awt.Color;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
@@ -23,6 +21,7 @@ import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 public final class ChatUtils {
@@ -59,7 +58,7 @@ public final class ChatUtils {
      * @return Returns a valid Bungee ChatColor.
      * @deprecated Use {@link net.kyori.adventure.text.format.TextColor#color(int, int, int)} instead.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     public static ChatColor fromRGB(final byte r, final byte g, final byte b) {
         return ChatColor.of(new Color(r, g, b));
@@ -102,9 +101,9 @@ public final class ChatUtils {
      * @deprecated Please use MiniMessage instead.
      * <a href="https://docs.adventure.kyori.net/minimessage.html">Read More</a>.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
-    public static String parseColor(@Nonnull String string) {
+    public static String parseColor(@NotNull String string) {
         string = parseColorAmp(string);
         string = parseColorAcc(string);
         string = parseColorTags(string);
@@ -115,9 +114,9 @@ public final class ChatUtils {
      * @deprecated Please use MiniMessage instead.
      * <a href="https://docs.adventure.kyori.net/minimessage.html">Read More</a>.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
-    public static String parseColorAmp(@Nonnull String string) {
+    public static String parseColorAmp(@NotNull String string) {
         string = string.replace("&&", "&");
         return ChatColor.translateAlternateColorCodes('&', string);
     }
@@ -126,9 +125,9 @@ public final class ChatUtils {
      * @deprecated Please use MiniMessage instead.
      * <a href="https://docs.adventure.kyori.net/minimessage.html">Read More</a>.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
-    public static String parseColorAcc(@Nonnull String string) {
+    public static String parseColorAcc(@NotNull String string) {
         return ChatColor.translateAlternateColorCodes('`', string);
     }
 
@@ -136,9 +135,9 @@ public final class ChatUtils {
      * @deprecated Please use MiniMessage instead.
      * <a href="https://docs.adventure.kyori.net/minimessage.html">Read More</a>.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
-    public static String parseColorTags(@Nonnull String string) {
+    public static String parseColorTags(@NotNull String string) {
         return string
             .replace("<black>", ChatColor.BLACK.toString())
             .replace("<dblue>", ChatColor.DARK_BLUE.toString())
@@ -257,7 +256,7 @@ public final class ChatUtils {
      * @param components The component / components to wrap.
      * @return Returns the normalised component, or empty if no components are passed.
      */
-    @Nonnull
+    @NotNull
     public static Component normaliseComponent(final Component... components) {
         if (ArrayUtils.isEmpty(components)) {
             return Component.empty();
@@ -276,7 +275,7 @@ public final class ChatUtils {
      * @param components The components to wrap.
      * @return Returns the normalised component, or empty if no components are passed.
      */
-    @Nonnull
+    @NotNull
     public static Component normaliseComponent(@Nullable final List<Component> components) {
         if (CollectionUtils.isEmpty(components)) {
             return Component.empty();
@@ -294,7 +293,7 @@ public final class ChatUtils {
      * @param component The component to stringify.
      * @return Returns a stringified version of the given component.
      */
-    @Nonnull
+    @NotNull
     public static String stringify(@Nullable final Component component) {
         return component == null || component == Component.empty() ? "" :
             CraftChatMessage.fromComponent(PaperAdventure.asVanilla(component));
@@ -317,7 +316,7 @@ public final class ChatUtils {
      * @return Generates a new text component that's specifically <i>NOT</i> italicised. Use this for item names and
      * lore.
      */
-    @Nonnull
+    @NotNull
     public static TextComponent newComponent() {
         return newComponent("");
     }
@@ -328,7 +327,7 @@ public final class ChatUtils {
      * @param content The text content for the component.
      * @return Returns the generated text component.
      */
-    @Nonnull
+    @NotNull
     public static TextComponent newComponent(final String content) {
         return Component.text(Objects.requireNonNull(content))
             .decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE);
@@ -399,5 +398,4 @@ public final class ChatUtils {
             //       name and lore, perhaps also enchantments, etc..
         );
     }
-
 }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/Componentify.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/Componentify.java
@@ -1,14 +1,15 @@
 package vg.civcraft.mc.civmodcore.chat;
 
-import javax.annotation.Nonnull;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class Componentify {
 
-    private static Component INTERNAL_addLocationWorld(final Location location) {
+    private static Component INTERNAL_addLocationWorld(@Nullable final Location location) {
         if (location.isWorldLoaded()) {
             return Component.text(location.getWorld().getName())
                 .hoverEvent(HoverEvent.showText(Component.text("World name")));
@@ -19,7 +20,7 @@ public final class Componentify {
         }
     }
 
-    public static Component fullLocation(@Nonnull final Location location) {
+    public static Component fullLocation(@NotNull final Location location) {
         final var component = Component.text();
         component.append(INTERNAL_addLocationWorld(location));
         component.append(Component.space());
@@ -45,7 +46,7 @@ public final class Componentify {
         return component.build();
     }
 
-    public static Component blockLocation(@Nonnull final Location location) {
+    public static Component blockLocation(@NotNull final Location location) {
         final var component = Component.text();
         component.append(INTERNAL_addLocationWorld(location));
         component.append(Component.space());

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/commands/CommandManager.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/commands/CommandManager.java
@@ -17,9 +17,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 
 /**
@@ -34,7 +34,7 @@ public class CommandManager extends BukkitCommandManager {
      *
      * @param plugin The plugin to bind this manager to.
      */
-    public CommandManager(@Nonnull final Plugin plugin) {
+    public CommandManager(@NotNull final Plugin plugin) {
         super(Objects.requireNonNull(plugin));
         this.logger = CivLogger.getLogger(plugin.getClass(), getClass());
     }
@@ -65,7 +65,7 @@ public class CommandManager extends BukkitCommandManager {
      * @param completions The completion manager is given. It is the same manager that can be reached via
      *                    {@link #getCommandCompletions()}.
      */
-    public void registerCompletions(@Nonnull final CommandCompletions<BukkitCommandCompletionContext> completions) {
+    public void registerCompletions(@NotNull final CommandCompletions<BukkitCommandCompletionContext> completions) {
         CommandHelpers.registerNoneCompletion(completions);
         CommandHelpers.registerMaterialsCompletion(completions);
         CommandHelpers.registerItemMaterialsCompletion(completions);
@@ -79,7 +79,7 @@ public class CommandManager extends BukkitCommandManager {
      * @param contexts The context manager is given. It is the same manager that can be reached via
      *                 {@link #getCommandContexts()}.
      */
-    public void registerContexts(@Nonnull final CommandContexts<BukkitCommandExecutionContext> contexts) {
+    public void registerContexts(@NotNull final CommandContexts<BukkitCommandExecutionContext> contexts) {
         CommandHelpers.registerConsoleSenderContext(contexts);
     }
 
@@ -90,7 +90,7 @@ public class CommandManager extends BukkitCommandManager {
      * @param forceReplace Whether to force replace any existing command.
      */
     @Override
-    public final void registerCommand(@Nonnull final BaseCommand command, final boolean forceReplace) {
+    public final void registerCommand(@NotNull final BaseCommand command, final boolean forceReplace) {
         super.registerCommand(Objects.requireNonNull(command), forceReplace);
         this.logger.info("Command [" + command.getClass().getSimpleName() + "] registered.");
         getTabCompletions(command.getClass()).forEach((method, annotation) -> {
@@ -110,7 +110,7 @@ public class CommandManager extends BukkitCommandManager {
      */
     @SuppressWarnings("unchecked")
     @Override
-    public final void unregisterCommand(@Nonnull final BaseCommand command) {
+    public final void unregisterCommand(@NotNull final BaseCommand command) {
         super.unregisterCommand(Objects.requireNonNull(command));
         this.logger.info("Command [" + command.getClass().getSimpleName() + "] unregistered.");
         final Map<String, CommandCompletionHandler<BukkitCommandCompletionContext>> internal;

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/commands/NamedCommand.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/commands/NamedCommand.java
@@ -2,7 +2,7 @@ package vg.civcraft.mc.civmodcore.commands;
 
 import co.aikar.commands.BaseCommand;
 import java.util.Objects;
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This class should be used when you can't use {@link co.aikar.commands.annotation.CommandAlias}.
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 public abstract class NamedCommand extends BaseCommand {
 
     @SuppressWarnings("deprecation")
-    public NamedCommand(@Nonnull final String command) {
+    public NamedCommand(@NotNull final String command) {
         super(Objects.requireNonNull(command));
     }
 

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/config/ConfigHelper.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/config/ConfigHelper.java
@@ -8,8 +8,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -20,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.inventory.items.EnchantUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.MaterialUtils;
@@ -39,7 +38,7 @@ public final class ConfigHelper {
      * @param key    The key of the section to retrieve.
      * @return Returns the configuration section at the given key, or returns a new, empty section.
      */
-    @Nonnull
+    @NotNull
     public static ConfigurationSection getSection(@NotNull final ConfigurationSection config,
                                                   @NotNull final String key) {
         ConfigurationSection found = config.getConfigurationSection(key);
@@ -57,7 +56,7 @@ public final class ConfigHelper {
      * @param key    The key to get the list of.
      * @return Returns a list of strings, which is never null.
      */
-    @Nonnull
+    @NotNull
     public static List<String> getStringList(@NotNull final ConfigurationSection config,
                                              @NotNull final String key) {
         if (config.isString(key)) {
@@ -77,7 +76,7 @@ public final class ConfigHelper {
      * @param parser The parser to convert the string value into the correct type.
      * @return Returns a list, or null.
      */
-    @Nonnull
+    @NotNull
     public static <T> List<T> parseList(@NotNull final ConfigurationSection config,
                                         @NotNull final String key,
                                         @NotNull final Function<String, T> parser) {
@@ -102,9 +101,9 @@ public final class ConfigHelper {
      * @param key    The key of the list.
      * @return Returns a list of materials, or null.
      */
-    @Nonnull
-    public static List<Material> parseMaterialList(@Nonnull final ConfigurationSection config,
-                                                   @Nonnull final String key) {
+    @NotNull
+    public static List<Material> parseMaterialList(@NotNull final ConfigurationSection config,
+                                                   @NotNull final String key) {
         return parseList(config, key, MaterialUtils::getMaterial);
     }
 
@@ -115,7 +114,7 @@ public final class ConfigHelper {
      * @param config ConfigurationSection to parse the items from
      * @return The item map created
      */
-    @Nonnull
+    @NotNull
     public static ItemMap parseItemMap(@Nullable final ConfigurationSection config) {
         final var result = new ItemMap();
         if (config == null) {
@@ -129,12 +128,12 @@ public final class ConfigHelper {
         return result;
     }
 
-    public static int parseTimeAsTicks(@Nonnull final String arg) {
-		return (int) (parseTime(arg, TimeUnit.MILLISECONDS) / 50L);
-	}
+    public static int parseTimeAsTicks(@NotNull final String arg) {
+        return (int) (parseTime(arg, TimeUnit.MILLISECONDS) / 50L);
+    }
 
-    public static long parseTime(@Nonnull final String arg,
-                                 @Nonnull final TimeUnit unit) {
+    public static long parseTime(@NotNull final String arg,
+                                 @NotNull final TimeUnit unit) {
         long millis = parseTime(arg);
         return unit.convert(millis, TimeUnit.MILLISECONDS);
     }
@@ -154,7 +153,7 @@ public final class ConfigHelper {
      * @param input Parsed string containing the time format
      * @return How many milliseconds the given time value is
      */
-    public static long parseTime(@Nonnull String input) {
+    public static long parseTime(@NotNull String input) {
         input = input.replace(" ", "").replace(",", "").toLowerCase();
         long result = 0;
         try {
@@ -230,9 +229,9 @@ public final class ConfigHelper {
         return result;
     }
 
-    @Nonnull
-    private static String getSuffix(@Nonnull final String arg,
-                                    @Nonnull final Predicate<Character> selector) {
+    @NotNull
+    private static String getSuffix(@NotNull final String arg,
+                                    @NotNull final Predicate<Character> selector) {
         StringBuilder number = new StringBuilder();
         for (int i = arg.length() - 1; i >= 0; i--) {
             if (selector.test(arg.charAt(i))) {
@@ -250,7 +249,7 @@ public final class ConfigHelper {
      * @param configurationSection ConfigurationSection to parse the effect from
      * @return The potion effect parsed
      */
-    @Nonnull
+    @NotNull
     public static List<PotionEffect> parsePotionEffects(@Nullable final ConfigurationSection configurationSection) {
         List<PotionEffect> potionEffects = Lists.newArrayList();
         if (configurationSection != null) {
@@ -363,12 +362,12 @@ public final class ConfigHelper {
      * @param valueConverter Converts strings to type V
      * @param mapToUse       The map to place parsed keys and values.
      */
-    public static <K, V> void parseKeyValueMap(@Nonnull final ConfigurationSection parent,
-                                               @Nonnull final String identifier,
-                                               @Nonnull final Logger logger,
-                                               @Nonnull final Function<String, K> keyConverter,
-                                               @Nonnull final Function<String, V> valueConverter,
-                                               @Nonnull final Map<K, V> mapToUse) {
+    public static <K, V> void parseKeyValueMap(@NotNull final ConfigurationSection parent,
+                                               @NotNull final String identifier,
+                                               @NotNull final Logger logger,
+                                               @NotNull final Function<String, K> keyConverter,
+                                               @NotNull final Function<String, V> valueConverter,
+                                               @NotNull final Map<K, V> mapToUse) {
         if (!parent.isConfigurationSection(identifier)) {
             return;
         }
@@ -397,8 +396,8 @@ public final class ConfigHelper {
      */
     @Nullable
     @Deprecated(forRemoval = true)
-    public static Enchantment parseEnchantment(@Nonnull final ConfigurationSection config,
-                                               @Nonnull final String key) {
+    public static Enchantment parseEnchantment(@NotNull final ConfigurationSection config,
+                                               @NotNull final String key) {
         return EnchantUtils.getEnchantment(config.getString(key));
     }
 

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/config/ConfigSection.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/config/ConfigSection.java
@@ -1,9 +1,9 @@
 package vg.civcraft.mc.civmodcore.config;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.bukkit.configuration.MemoryConfiguration;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Class is intended to be used by implementations of {@link ConfigurationSerializable} during the deserialization
@@ -15,7 +15,7 @@ public class ConfigSection extends MemoryConfiguration {
      * @param data The data to create a new ConfigSection from.
      * @return Returns a new ConfigSection.
      */
-    public static ConfigSection fromData(@Nonnull final Map<String, Object> data) {
+    public static ConfigSection fromData(@NotNull final Map<String, Object> data) {
         final var section = new ConfigSection();
         for (var entry : data.entrySet()) {
             section.set(entry.getKey(), entry.getValue());

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/dao/ConnectionPool.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/dao/ConnectionPool.java
@@ -8,9 +8,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Objects;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Handy Connection Pool / Database wrapper for use by all plugins.
@@ -30,7 +30,7 @@ public class ConnectionPool {
      *
      * @param credentials The credentials to connect with.
      */
-    public ConnectionPool(@Nonnull final DatabaseCredentials credentials) {
+    public ConnectionPool(@NotNull final DatabaseCredentials credentials) {
         this.credentials = Objects.requireNonNull(credentials,
             "Cannot create a ConnectionPool with a null set of credentials.");
         HikariConfig config = new HikariConfig();
@@ -91,7 +91,7 @@ public class ConnectionPool {
      *
      * @return Returns the credentials being used.
      */
-    @Nonnull
+    @NotNull
     public DatabaseCredentials getCredentials() {
         return this.credentials;
     }
@@ -102,7 +102,7 @@ public class ConnectionPool {
      * @return A new Connection
      * @throws SQLException
      */
-    @Nonnull
+    @NotNull
     public Connection getConnection() throws SQLException {
         available();
         return this.datasource.getConnection();

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/dao/DatabaseCredentials.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/dao/DatabaseCredentials.java
@@ -2,11 +2,11 @@ package vg.civcraft.mc.civmodcore.dao;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.collections4.MapUtils;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.util.NumberConversions;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.utilities.MoreMapUtils;
 
 /**
@@ -26,7 +26,7 @@ public record DatabaseCredentials(String username,
                                   long maxLifetime)
     implements ConfigurationSerializable {
 
-    @Nonnull
+    @NotNull
     @Override
     public Map<String, Object> serialize() {
         final var data = new HashMap<String, Object>(10);
@@ -44,7 +44,7 @@ public record DatabaseCredentials(String username,
     }
 
     @Nullable
-    public static DatabaseCredentials deserialize(@Nonnull final Map<String, Object> data) {
+    public static DatabaseCredentials deserialize(@NotNull final Map<String, Object> data) {
         if (MapUtils.isEmpty(data)) {
             return null;
         }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/dao/DatabaseMigration.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/dao/DatabaseMigration.java
@@ -1,8 +1,8 @@
 package vg.civcraft.mc.civmodcore.dao;
 
 import java.sql.SQLException;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Interface to allow for more object-oriented based migration. I've noticed as plugins get older, their DAOs get
@@ -27,7 +27,7 @@ public interface DatabaseMigration {
     /**
      * @return Returns this migration's queries. Each query will be run in sequences. Must not be null or empty!
      */
-    @Nonnull
+    @NotNull
     String[] getMigrationQueries();
 
     /**
@@ -35,14 +35,14 @@ public interface DatabaseMigration {
      *
      * @return Returns whether the callback completed successfully.
      */
-    default boolean migrationCallback(@Nonnull final ManagedDatasource datasource) throws SQLException {
+    default boolean migrationCallback(@NotNull final ManagedDatasource datasource) throws SQLException {
         return true;
     }
 
     /**
      * @param datasource The datasource to register this migration to.
      */
-    default void registerMigration(@Nonnull final ManagedDatasource datasource) {
+    default void registerMigration(@NotNull final ManagedDatasource datasource) {
         final var queries = getMigrationQueries();
         if (ArrayUtils.isEmpty(queries)) {
             throw new IllegalArgumentException("Migration queries cannot be null or empty!");

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/dao/ManagedDatasource.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/dao/ManagedDatasource.java
@@ -16,9 +16,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.ACivMod;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 import vg.civcraft.mc.civmodcore.utilities.MoreCollectionUtils;
@@ -181,7 +181,7 @@ public class ManagedDatasource {
      * @return Returns
      */
     @Nullable
-    public static ManagedDatasource construct(@Nonnull final ACivMod plugin,
+    public static ManagedDatasource construct(@NotNull final ACivMod plugin,
                                               @Nullable final DatabaseCredentials credentials) {
         final var logger = CivLogger.getLogger(plugin.getClass(), ManagedDatasource.class);
         if (credentials == null) {

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/ClonedInventory.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/ClonedInventory.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Spliterator;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -15,6 +13,8 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.utilities.MoreArrayUtils;
 
 /**
@@ -58,15 +58,15 @@ public final class ClonedInventory implements Inventory {
         return this.inventory.addItem(items);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public HashMap<Integer, ItemStack> removeItem(final ItemStack... items) throws IllegalArgumentException {
         return this.inventory.removeItem(items);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public HashMap<Integer, ItemStack> removeItemAnySlot(@Nonnull ItemStack... items) throws IllegalArgumentException {
+    public HashMap<Integer, ItemStack> removeItemAnySlot(@NotNull ItemStack... items) throws IllegalArgumentException {
         return this.inventory.removeItemAnySlot(items);
     }
 
@@ -91,7 +91,7 @@ public final class ClonedInventory implements Inventory {
     }
 
     @Override
-    public boolean contains(@Nonnull final Material material) throws IllegalArgumentException {
+    public boolean contains(@NotNull final Material material) throws IllegalArgumentException {
         return this.inventory.contains(material);
     }
 
@@ -101,7 +101,7 @@ public final class ClonedInventory implements Inventory {
     }
 
     @Override
-    public boolean contains(@Nonnull final Material material, final int amount) throws IllegalArgumentException {
+    public boolean contains(@NotNull final Material material, final int amount) throws IllegalArgumentException {
         return this.inventory.contains(material, amount);
     }
 
@@ -116,7 +116,7 @@ public final class ClonedInventory implements Inventory {
     }
 
     @Override
-    public HashMap<Integer, ? extends ItemStack> all(@Nonnull final Material material) throws IllegalArgumentException {
+    public HashMap<Integer, ? extends ItemStack> all(@NotNull final Material material) throws IllegalArgumentException {
         return this.inventory.all(material);
     }
 
@@ -126,12 +126,12 @@ public final class ClonedInventory implements Inventory {
     }
 
     @Override
-    public int first(@Nonnull final Material material) throws IllegalArgumentException {
+    public int first(@NotNull final Material material) throws IllegalArgumentException {
         return this.inventory.first(material);
     }
 
     @Override
-    public int first(@Nonnull final ItemStack item) {
+    public int first(@NotNull final ItemStack item) {
         return this.inventory.first(item);
     }
 
@@ -146,12 +146,12 @@ public final class ClonedInventory implements Inventory {
     }
 
     @Override
-    public void remove(@Nonnull final Material material) throws IllegalArgumentException {
+    public void remove(@NotNull final Material material) throws IllegalArgumentException {
         this.inventory.remove(material);
     }
 
     @Override
-    public void remove(@Nonnull final ItemStack item) {
+    public void remove(@NotNull final ItemStack item) {
         this.inventory.remove(item);
     }
 
@@ -191,7 +191,7 @@ public final class ClonedInventory implements Inventory {
         return this.inventory.getHolder(useSnapshot);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ListIterator<ItemStack> iterator() {
         return this.inventory.iterator();

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/InventoryUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/InventoryUtils.java
@@ -6,13 +6,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.ArrayUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 public final class InventoryUtils {
@@ -95,7 +95,7 @@ public final class InventoryUtils {
      *
      * @param inventory The inventory to clear of items.
      */
-    public static void clearInventory(@Nonnull final Inventory inventory) {
+    public static void clearInventory(@NotNull final Inventory inventory) {
         final ItemStack[] contents = inventory.getContents();
         Arrays.fill(contents, new ItemStack(Material.AIR));
         inventory.setContents(contents);

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/gui/IClickable.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/gui/IClickable.java
@@ -1,16 +1,16 @@
 package vg.civcraft.mc.civmodcore.inventory.gui;
 
-import javax.annotation.Nonnull;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class IClickable {
 
     /**
      * @return Which item stack represents this clickable when it is initially loaded into the inventory.
      */
-    @Nonnull
+    @NotNull
     public abstract ItemStack getItemStack();
 
     /**
@@ -20,7 +20,7 @@ public abstract class IClickable {
      * @param inventory Inventory it was added to
      * @param slot      Slot in which it was added
      */
-    public abstract void addedToInventory(@Nonnull final ClickableInventory inventory, final int slot);
+    public abstract void addedToInventory(@NotNull final ClickableInventory inventory, final int slot);
 
     /**
      * General method called whenever this clickable is clicked with a type that did
@@ -28,7 +28,7 @@ public abstract class IClickable {
      *
      * @param clicker Player who clicked
      */
-    protected abstract void clicked(@Nonnull final Player clicker);
+    protected abstract void clicked(@NotNull final Player clicker);
 
     /**
      * Called when a player double clicks this clickable, overwrite to define
@@ -36,7 +36,7 @@ public abstract class IClickable {
      *
      * @param clicker Player who clicked
      */
-    protected void onDoubleClick(@Nonnull final Player clicker) {
+    protected void onDoubleClick(@NotNull final Player clicker) {
         clicked(clicker);
     }
 
@@ -47,7 +47,7 @@ public abstract class IClickable {
      *
      * @param clicker Player who clicked
      */
-    protected void onDrop(@Nonnull final Player clicker) {
+    protected void onDrop(@NotNull final Player clicker) {
         clicked(clicker);
     }
 
@@ -58,7 +58,7 @@ public abstract class IClickable {
      *
      * @param clicker Player who clicked
      */
-    protected void onControlDrop(@Nonnull final Player clicker) {
+    protected void onControlDrop(@NotNull final Player clicker) {
         clicked(clicker);
     }
 
@@ -68,7 +68,7 @@ public abstract class IClickable {
      *
      * @param clicker Player who clicked
      */
-    protected void onLeftClick(@Nonnull final Player clicker) {
+    protected void onLeftClick(@NotNull final Player clicker) {
         clicked(clicker);
     }
 
@@ -78,7 +78,7 @@ public abstract class IClickable {
      *
      * @param clicker Player who clicked
      */
-    protected void onRightClick(@Nonnull final Player clicker) {
+    protected void onRightClick(@NotNull final Player clicker) {
         clicked(clicker);
     }
 
@@ -88,7 +88,7 @@ public abstract class IClickable {
      *
      * @param clicker Player who clicked
      */
-    protected void onMiddleClick(@Nonnull final Player clicker) {
+    protected void onMiddleClick(@NotNull final Player clicker) {
         clicked(clicker);
     }
 
@@ -98,7 +98,7 @@ public abstract class IClickable {
      *
      * @param clicker Player who clicked
      */
-    protected void onShiftLeftClick(@Nonnull final Player clicker) {
+    protected void onShiftLeftClick(@NotNull final Player clicker) {
         clicked(clicker);
     }
 
@@ -108,12 +108,12 @@ public abstract class IClickable {
      *
      * @param clicker Player who clicked
      */
-    protected void onShiftRightClick(@Nonnull final Player clicker) {
+    protected void onShiftRightClick(@NotNull final Player clicker) {
         clicked(clicker);
     }
 
-    public void handleClick(@Nonnull final Player clicker,
-                            @Nonnull final ClickType type) {
+    public void handleClick(@NotNull final Player clicker,
+                            @NotNull final ClickType type) {
         switch (type) {
             case CONTROL_DROP -> onControlDrop(clicker);
             case DOUBLE_CLICK -> onDoubleClick(clicker);

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/EnchantUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/EnchantUtils.java
@@ -10,8 +10,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.translation.Translatable;
 import org.apache.commons.collections4.CollectionUtils;
@@ -19,6 +17,8 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.CivModCorePlugin;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
@@ -34,7 +34,7 @@ public final class EnchantUtils {
     /**
      * Loads enchantment names and initials from the config.
      */
-    public static void loadEnchantAbbreviations(@Nonnull final CivModCorePlugin plugin) {
+    public static void loadEnchantAbbreviations(@NotNull final CivModCorePlugin plugin) {
         final var logger = CivLogger.getLogger(EnchantUtils.class);
         ENCHANT_ABBR.clear();
         final File enchantsFile = plugin.getDataFile("enchants.yml");
@@ -143,7 +143,7 @@ public final class EnchantUtils {
      * @param item The item to retrieve the enchantments from.
      * @return Returns the item's enchantments, which are never null.
      */
-    @Nonnull
+    @NotNull
     public static Map<Enchantment, Integer> getEnchantments(@Nullable final ItemStack item) {
         return item == null ? ImmutableMap.of() : item.getEnchantments();
     }
@@ -157,8 +157,8 @@ public final class EnchantUtils {
      * @return Returns true if the enchantment was successfully added.
      * @see EnchantUtils#isSafeEnchantment(Enchantment, int)
      */
-    public static boolean addEnchantment(@Nonnull final ItemStack item,
-                                         @Nonnull final Enchantment enchantment,
+    public static boolean addEnchantment(@NotNull final ItemStack item,
+                                         @NotNull final Enchantment enchantment,
                                          final int level) {
         return addEnchantment(item, enchantment, level, true);
     }
@@ -173,8 +173,8 @@ public final class EnchantUtils {
      * @return Returns true if the enchantment was successfully added.
      * @see EnchantUtils#isSafeEnchantment(Enchantment, int)
      */
-    public static boolean addEnchantment(@Nonnull final ItemStack item,
-                                         @Nonnull final Enchantment enchantment,
+    public static boolean addEnchantment(@NotNull final ItemStack item,
+                                         @NotNull final Enchantment enchantment,
                                          final int level,
                                          final boolean onlyAllowSafeEnchantments) {
         return ItemUtils.handleItemMeta(Objects.requireNonNull(item), (ItemMeta meta) ->
@@ -188,7 +188,7 @@ public final class EnchantUtils {
      * @param enchant The enchantment to remove from the item.
      * @return Returns true if the enchantment was successfully removed.
      */
-    public static boolean removeEnchantment(@Nonnull final ItemStack item,
+    public static boolean removeEnchantment(@NotNull final ItemStack item,
                                             @Nullable final Enchantment enchant) {
         return enchant == null
             || ItemUtils.handleItemMeta(Objects.requireNonNull(item),
@@ -200,7 +200,7 @@ public final class EnchantUtils {
      *
      * @param item The item to clear enchantment from.
      */
-    public static void clearEnchantments(@Nonnull final ItemStack item) {
+    public static void clearEnchantments(@NotNull final ItemStack item) {
         ItemUtils.handleItemMeta(Objects.requireNonNull(item), (ItemMeta meta) -> {
             meta.getEnchants().forEach((key, value) -> meta.removeEnchant(key));
             return true;

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemUtils.java
@@ -5,8 +5,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.translation.Translatable;
 import org.bukkit.Material;
@@ -15,6 +13,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 
 /**
@@ -30,8 +30,8 @@ public final class ItemUtils {
      * @deprecated Use {@link Component#translatable(Translatable)} instead.
      */
     @Deprecated
-    @Nonnull
-    public static String getItemName(@Nonnull final Material material) {
+    @NotNull
+    public static String getItemName(@NotNull final Material material) {
         return ChatUtils.stringify(Component.translatable(Objects.requireNonNull(material)));
     }
 
@@ -248,7 +248,7 @@ public final class ItemUtils {
      * @param name The display name to set on the item.
      * @throws IllegalArgumentException Throws when the given item has no meta.
      */
-    public static void setComponentDisplayName(@Nonnull final ItemStack item,
+    public static void setComponentDisplayName(@NotNull final ItemStack item,
                                                @Nullable final Component name) {
         final var meta = Objects.requireNonNull(getItemMeta(item),
             "Cannot set that display name: item has no meta.");
@@ -262,7 +262,7 @@ public final class ItemUtils {
      * @param item The item to retrieve the lore from.
      * @return Returns the lore, which is never null.
      */
-    @Nonnull
+    @NotNull
     public static List<Component> getComponentLore(@Nullable final ItemStack item) {
         final var meta = getItemMeta(item);
         return meta == null ? new ArrayList<>(0) : MetaUtils.getComponentLore(meta);
@@ -276,7 +276,7 @@ public final class ItemUtils {
      * @throws IllegalArgumentException Throws when the given item has no meta.
      * @see ItemUtils#clearLore(ItemStack)
      */
-    public static void setComponentLore(@Nonnull final ItemStack item,
+    public static void setComponentLore(@NotNull final ItemStack item,
                                         @Nullable final Component... lines) {
         setComponentLore(item, lines == null ? null : Arrays.asList(lines));
     }
@@ -289,7 +289,7 @@ public final class ItemUtils {
      * @throws IllegalArgumentException Throws when the given item has no meta.
      * @see ItemUtils#clearLore(ItemStack)
      */
-    public static void setComponentLore(@Nonnull final ItemStack item,
+    public static void setComponentLore(@NotNull final ItemStack item,
                                         @Nullable final List<Component> lines) {
         final var meta = Objects.requireNonNull(getItemMeta(item),
             "Cannot set that lore: item has no meta.");
@@ -303,7 +303,7 @@ public final class ItemUtils {
      * @param item The item to clear lore of.
      * @throws IllegalArgumentException Throws when the given item has no meta.
      */
-    public static void clearLore(@Nonnull final ItemStack item) {
+    public static void clearLore(@NotNull final ItemStack item) {
         setComponentLore(item, (List<Component>) null);
     }
 
@@ -314,7 +314,7 @@ public final class ItemUtils {
      * @param lines The lore to append to the item.
      * @throws IllegalArgumentException Throws when the given item has no meta.
      */
-    public static void addComponentLore(@Nonnull final ItemStack item,
+    public static void addComponentLore(@NotNull final ItemStack item,
                                         @Nullable final Component... lines) {
         addComponentLore(item, false, lines);
     }
@@ -326,7 +326,7 @@ public final class ItemUtils {
      * @param lines The lore to append to the item.
      * @throws IllegalArgumentException Throws when the given item has no meta.
      */
-    public static void addComponentLore(@Nonnull final ItemStack item,
+    public static void addComponentLore(@NotNull final ItemStack item,
                                         @Nullable final List<Component> lines) {
         addComponentLore(item, false, lines);
     }
@@ -339,7 +339,7 @@ public final class ItemUtils {
      * @param lines   The lore to append to the item.
      * @throws IllegalArgumentException Throws when the given item has no meta.
      */
-    public static void addComponentLore(@Nonnull final ItemStack item,
+    public static void addComponentLore(@NotNull final ItemStack item,
                                         final boolean prepend,
                                         @Nullable final Component... lines) {
         addComponentLore(item, prepend, lines == null ? null : Arrays.asList(lines));
@@ -353,7 +353,7 @@ public final class ItemUtils {
      * @param lines   The lore to append to the item.
      * @throws IllegalArgumentException Throws when the given item has no meta.
      */
-    public static void addComponentLore(@Nonnull final ItemStack item,
+    public static void addComponentLore(@NotNull final ItemStack item,
                                         final boolean prepend,
                                         @Nullable final List<Component> lines) {
         final var meta = Objects.requireNonNull(getItemMeta(item),
@@ -443,7 +443,7 @@ public final class ItemUtils {
      * {@link #setComponentDisplayName(ItemStack, Component)} instead.
      */
     @Deprecated
-    public static void setDisplayName(@Nonnull final ItemStack item,
+    public static void setDisplayName(@NotNull final ItemStack item,
                                       @Nullable final String name) {
         final var meta = Objects.requireNonNull(getItemMeta(item),
             "Cannot set that display name: item has no meta.");
@@ -459,7 +459,7 @@ public final class ItemUtils {
      * @deprecated Has been deprecated due to Paper's move to Kyori's Adventure. Use
      * {@link #getComponentLore(ItemStack)} instead.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     public static List<String> getLore(@Nullable final ItemStack item) {
         final var meta = getItemMeta(item);
@@ -477,7 +477,7 @@ public final class ItemUtils {
      * {@link #setComponentLore(ItemStack, Component...)} instead.
      */
     @Deprecated
-    public static void setLore(@Nonnull final ItemStack item,
+    public static void setLore(@NotNull final ItemStack item,
                                @Nullable final String... lines) {
         setLore(item, lines == null ? null : Arrays.asList(lines));
     }
@@ -493,7 +493,7 @@ public final class ItemUtils {
      * {@link #setComponentLore(ItemStack, List)} instead.
      */
     @Deprecated
-    public static void setLore(@Nonnull final ItemStack item,
+    public static void setLore(@NotNull final ItemStack item,
                                @Nullable final List<String> lines) {
         final var meta = Objects.requireNonNull(getItemMeta(item),
             "Cannot set that lore: item has no meta.");
@@ -511,7 +511,7 @@ public final class ItemUtils {
      * {@link #addComponentLore(ItemStack, Component...)} instead.
      */
     @Deprecated
-    public static void addLore(@Nonnull final ItemStack item,
+    public static void addLore(@NotNull final ItemStack item,
                                @Nullable final String... lines) {
         addLore(item, false, lines);
     }
@@ -526,7 +526,7 @@ public final class ItemUtils {
      * {@link #addComponentLore(ItemStack, List)} instead.
      */
     @Deprecated
-    public static void addLore(@Nonnull final ItemStack item,
+    public static void addLore(@NotNull final ItemStack item,
                                @Nullable final List<String> lines) {
         addLore(item, false, lines);
     }
@@ -542,7 +542,7 @@ public final class ItemUtils {
      * {@link #addComponentLore(ItemStack, boolean, Component...)} instead.
      */
     @Deprecated
-    public static void addLore(@Nonnull final ItemStack item,
+    public static void addLore(@NotNull final ItemStack item,
                                final boolean prepend,
                                @Nullable final String... lines) {
         addLore(item, prepend, lines == null ? null : Arrays.asList(lines));
@@ -559,7 +559,7 @@ public final class ItemUtils {
      * {@link #addComponentLore(ItemStack, boolean, List)} instead.
      */
     @Deprecated
-    public static void addLore(@Nonnull final ItemStack item,
+    public static void addLore(@NotNull final ItemStack item,
                                final boolean prepend,
                                @Nullable final List<String> lines) {
         final var meta = Objects.requireNonNull(getItemMeta(item),

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MaterialUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MaterialUtils.java
@@ -4,11 +4,11 @@ import com.destroystokyo.paper.MaterialTags;
 import com.google.common.math.IntMath;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.Tag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * <p>See <a href="https://github.com/Protonull/BukkitReport/tree/master/reports">BukkitReports</a>.</p>
@@ -57,7 +57,7 @@ public final class MaterialUtils {
      * @param object Object to base returned material on
      * @return Material hash of the given object
      */
-    @Nonnull
+    @NotNull
     public static Material getMaterialHash(@Nullable final Object object) {
         if (object == null) {
             return HASH_MATERIALS.get(0);

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MetaUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MetaUtils.java
@@ -6,13 +6,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import org.apache.commons.collections4.CollectionUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 
 /**
@@ -77,8 +77,8 @@ public final class MetaUtils {
      * @param meta The item meta to retrieve the lore from.
      * @return Returns the lore, which is never null.
      */
-    @Nonnull
-    public static List<Component> getComponentLore(@Nonnull final ItemMeta meta) {
+    @NotNull
+    public static List<Component> getComponentLore(@NotNull final ItemMeta meta) {
         final List<Component> lore = meta.lore();
         if (lore == null) {
             return new ArrayList<>(0);
@@ -92,7 +92,7 @@ public final class MetaUtils {
      * @param meta  The meta to set the lore to.
      * @param lines The lore lines to set.
      */
-    public static void setComponentLore(@Nonnull final ItemMeta meta,
+    public static void setComponentLore(@NotNull final ItemMeta meta,
                                         @Nullable final Component... lines) {
         setComponentLore(meta, lines == null ? null : Arrays.asList(lines));
     }
@@ -103,7 +103,7 @@ public final class MetaUtils {
      * @param meta  The meta to set the lore to.
      * @param lines The lore lines to set.
      */
-    public static void setComponentLore(@Nonnull final ItemMeta meta,
+    public static void setComponentLore(@NotNull final ItemMeta meta,
                                         @Nullable List<Component> lines) {
         if (lines == null) {
             clearLore(meta);
@@ -119,7 +119,7 @@ public final class MetaUtils {
      *
      * @param meta The item meta to clear the lore of.
      */
-    public static void clearLore(@Nonnull final ItemMeta meta) {
+    public static void clearLore(@NotNull final ItemMeta meta) {
         meta.lore(null);
     }
 
@@ -129,7 +129,7 @@ public final class MetaUtils {
      * @param meta  The item meta to append the lore to.
      * @param lines The lore to append to the item meta.
      */
-    public static void addComponentLore(@Nonnull final ItemMeta meta,
+    public static void addComponentLore(@NotNull final ItemMeta meta,
                                         @Nullable final Component... lines) {
         addComponentLore(meta, false, lines);
     }
@@ -140,7 +140,7 @@ public final class MetaUtils {
      * @param meta  The item meta to append the lore to.
      * @param lines The lore to append to the item meta.
      */
-    public static void addComponentLore(@Nonnull final ItemMeta meta,
+    public static void addComponentLore(@NotNull final ItemMeta meta,
                                         @Nullable final List<Component> lines) {
         addComponentLore(meta, false, lines);
     }
@@ -152,7 +152,7 @@ public final class MetaUtils {
      * @param prepend If set to true, the lore will be prepended instead of appended.
      * @param lines   The lore to append to the item meta.
      */
-    public static void addComponentLore(@Nonnull final ItemMeta meta,
+    public static void addComponentLore(@NotNull final ItemMeta meta,
                                         final boolean prepend,
                                         @Nullable final Component... lines) {
         addComponentLore(meta, prepend, lines == null ? null : Arrays.asList(lines));
@@ -165,7 +165,7 @@ public final class MetaUtils {
      * @param prepend If set to true, the lore will be prepended instead of appended.
      * @param lines   The lore to append to the item meta.
      */
-    public static void addComponentLore(@Nonnull final ItemMeta meta,
+    public static void addComponentLore(@NotNull final ItemMeta meta,
                                         final boolean prepend,
                                         @Nullable List<Component> lines) {
         if (CollectionUtils.isEmpty(lines)) {
@@ -198,8 +198,8 @@ public final class MetaUtils {
      * Use {@link #getComponentLore(ItemMeta)} instead.
      */
     @Deprecated
-    @Nonnull
-    public static List<String> getLore(@Nonnull final ItemMeta meta) {
+    @NotNull
+    public static List<String> getLore(@NotNull final ItemMeta meta) {
         final List<String> lore = meta.getLore();
         if (lore == null) {
             return new ArrayList<>(0);
@@ -216,7 +216,7 @@ public final class MetaUtils {
      * Use {@link #addComponentLore(ItemMeta, Component...)} instead.
      */
     @Deprecated
-    public static void addLore(@Nonnull final ItemMeta meta,
+    public static void addLore(@NotNull final ItemMeta meta,
                                @Nullable final String... lines) {
         addLore(meta, false, lines);
     }
@@ -230,7 +230,7 @@ public final class MetaUtils {
      * Use {@link #addComponentLore(ItemMeta, List)} instead.
      */
     @Deprecated
-    public static void addLore(@Nonnull final ItemMeta meta,
+    public static void addLore(@NotNull final ItemMeta meta,
                                @Nullable final List<String> lines) {
         addLore(meta, false, lines);
     }
@@ -245,7 +245,7 @@ public final class MetaUtils {
      * Use {@link #addComponentLore(ItemMeta, boolean, Component...)} instead.
      */
     @Deprecated
-    public static void addLore(@Nonnull final ItemMeta meta,
+    public static void addLore(@NotNull final ItemMeta meta,
                                final boolean prepend,
                                @Nullable final String... lines) {
         addLore(meta, prepend, lines == null ? null : Arrays.asList(lines));
@@ -261,7 +261,7 @@ public final class MetaUtils {
      * Use {@link #addComponentLore(ItemMeta, boolean, List)} instead.
      */
     @Deprecated
-    public static void addLore(@Nonnull final ItemMeta meta,
+    public static void addLore(@NotNull final ItemMeta meta,
                                final boolean prepend,
                                @Nullable List<String> lines) {
         if (CollectionUtils.isEmpty(lines)) {

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MoreTags.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MoreTags.java
@@ -5,8 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
@@ -14,6 +12,8 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.block.data.Ageable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 
@@ -302,13 +302,13 @@ public final class MoreTags {
             return this.values.contains(value);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public Set<T> getValues() {
             return this.values;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public NamespacedKey getKey() {
             return this.key;

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/PotionUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/PotionUtils.java
@@ -2,8 +2,6 @@ package vg.civcraft.mc.civmodcore.inventory.items;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectAVLTreeMap;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.translation.Translatable;
@@ -14,6 +12,8 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 
 public final class PotionUtils {
@@ -24,8 +24,8 @@ public final class PotionUtils {
      * @param type The potion type to get a translatable component for.
      * @return Returns a translatable component for the given potion type.
      */
-    @Nonnull
-    public static TranslatableComponent asTranslatable(@Nonnull final PotionType type) {
+    @NotNull
+    public static TranslatableComponent asTranslatable(@NotNull final PotionType type) {
         return asTranslatable(Material.POTION, type);
     }
 
@@ -34,9 +34,9 @@ public final class PotionUtils {
      * @param type     The potion type to get a translatable component for.
      * @return Returns a translatable component for the given potion type.
      */
-    @Nonnull
-    public static TranslatableComponent asTranslatable(@Nonnull final Material material,
-                                                       @Nonnull final PotionType type) {
+    @NotNull
+    public static TranslatableComponent asTranslatable(@NotNull final Material material,
+                                                       @NotNull final PotionType type) {
         if (!MoreTags.POTIONS.isTagged(material)) {
             throw new IllegalArgumentException("That is not a recognised potion material! [" + material.name() + "]");
         }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/SpawnEggUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/SpawnEggUtils.java
@@ -5,10 +5,10 @@ import com.google.common.collect.ImmutableBiMap;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 
 /**

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/nbt/NBTDeserializer.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/nbt/NBTDeserializer.java
@@ -1,6 +1,6 @@
 package vg.civcraft.mc.civmodcore.nbt;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 
 /**
@@ -10,7 +10,7 @@ import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 @FunctionalInterface
 public interface NBTDeserializer<T extends NBTSerializable> {
 
-    @Nonnull
-    T fromNBT(@Nonnull final NBTCompound nbt);
+    @NotNull
+    T fromNBT(@NotNull final NBTCompound nbt);
 
 }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/nbt/NBTSerializable.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/nbt/NBTSerializable.java
@@ -1,7 +1,7 @@
 package vg.civcraft.mc.civmodcore.nbt;
 
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.NotImplementedException;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 
 public interface NBTSerializable {
@@ -13,7 +13,7 @@ public interface NBTSerializable {
      *            {@link NBTSerializationException} if it is. You can generally assume that the NBTCompound is new and
      *            therefore empty, but you <i>may</i> wish to check that.
      */
-    void toNBT(@Nonnull final NBTCompound nbt);
+    void toNBT(@NotNull final NBTCompound nbt);
 
     /**
      * <p>Deserializes a given NBTCompound into a new class instance.</p>
@@ -24,8 +24,8 @@ public interface NBTSerializable {
      *            {@link NBTSerializationException} if it is.
      * @return Returns a new instance of this class.
      */
-    @Nonnull
-    public static NBTSerializable fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static NBTSerializable fromNBT(@NotNull final NBTCompound nbt) {
         throw new NotImplementedException("Please implement me on your class!");
     }
 

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/pdc/AbstractPersistentDataType.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/pdc/AbstractPersistentDataType.java
@@ -1,17 +1,17 @@
 package vg.civcraft.mc.civmodcore.pdc;
 
 import java.util.Objects;
-import javax.annotation.Nonnull;
 import org.bukkit.persistence.PersistentDataAdapterContext;
 import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class AbstractPersistentDataType<P, C> implements PersistentDataType<P, C> {
 
     protected final Class<P> primitiveClass;
     protected final Class<C> complexClass;
 
-    public AbstractPersistentDataType(@Nonnull final Class<P> primitiveClass,
-                                      @Nonnull final Class<C> complexClass) {
+    public AbstractPersistentDataType(@NotNull final Class<P> primitiveClass,
+                                      @NotNull final Class<C> complexClass) {
         this.primitiveClass = Objects.requireNonNull(primitiveClass);
         this.complexClass = Objects.requireNonNull(complexClass);
     }
@@ -19,7 +19,7 @@ public abstract class AbstractPersistentDataType<P, C> implements PersistentData
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
     public final Class<P> getPrimitiveType() {
         return this.primitiveClass;
@@ -28,7 +28,7 @@ public abstract class AbstractPersistentDataType<P, C> implements PersistentData
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
     public final Class<C> getComplexType() {
         return this.complexClass;
@@ -37,17 +37,17 @@ public abstract class AbstractPersistentDataType<P, C> implements PersistentData
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
-    public abstract P toPrimitive(@Nonnull C instance,
-                                  @Nonnull PersistentDataAdapterContext adapter);
+    public abstract P toPrimitive(@NotNull C instance,
+                                  @NotNull PersistentDataAdapterContext adapter);
 
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
-    public abstract C fromPrimitive(@Nonnull P raw,
-                                    @Nonnull PersistentDataAdapterContext adapter);
+    public abstract C fromPrimitive(@NotNull P raw,
+                                    @NotNull PersistentDataAdapterContext adapter);
 
 }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/pdc/PersistentDataTypes.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/pdc/PersistentDataTypes.java
@@ -1,10 +1,10 @@
 package vg.civcraft.mc.civmodcore.pdc;
 
-import javax.annotation.Nonnull;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.bukkit.persistence.PersistentDataAdapterContext;
 import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
 
 public final class PersistentDataTypes {
 
@@ -14,17 +14,17 @@ public final class PersistentDataTypes {
      * Boolean data type... because <i>believe it or not</i> but PDC doesn't already have this ಠ_ಠ
      */
     public static final PersistentDataType<Byte, Boolean> BOOLEAN = new AbstractPersistentDataType<>(Byte.class, Boolean.class) {
-        @Nonnull
+        @NotNull
         @Override
-        public Byte toPrimitive(@Nonnull final Boolean bool,
-                                @Nonnull final PersistentDataAdapterContext adapter) {
+        public Byte toPrimitive(@NotNull final Boolean bool,
+                                @NotNull final PersistentDataAdapterContext adapter) {
             return (byte) (bool ? 1 : 0);
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public Boolean fromPrimitive(@Nonnull final Byte raw,
-                                     @Nonnull final PersistentDataAdapterContext adapter) {
+        public Boolean fromPrimitive(@NotNull final Byte raw,
+                                     @NotNull final PersistentDataAdapterContext adapter) {
             return raw != (byte) 0;
         }
     };
@@ -33,17 +33,17 @@ public final class PersistentDataTypes {
      * Converts Components to Strings and vice versa.
      */
     public static final PersistentDataType<String, Component> COMPONENT = new AbstractPersistentDataType<>(String.class, Component.class) {
-        @Nonnull
+        @NotNull
         @Override
-        public String toPrimitive(@Nonnull final Component component,
-                                  @Nonnull final PersistentDataAdapterContext adapter) {
+        public String toPrimitive(@NotNull final Component component,
+                                  @NotNull final PersistentDataAdapterContext adapter) {
             return GsonComponentSerializer.gson().serialize(component);
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public Component fromPrimitive(@Nonnull final String raw,
-                                       @Nonnull final PersistentDataAdapterContext adapter) {
+        public Component fromPrimitive(@NotNull final String raw,
+                                       @NotNull final PersistentDataAdapterContext adapter) {
             return GsonComponentSerializer.gson().deserialize(raw);
         }
     };

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/pdc/PersistentEnumDataType.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/pdc/PersistentEnumDataType.java
@@ -1,9 +1,9 @@
 package vg.civcraft.mc.civmodcore.pdc;
 
 import java.util.Objects;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.EnumUtils;
 import org.bukkit.persistence.PersistentDataAdapterContext;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This class enables the easy encoding and decoding of enums.
@@ -18,7 +18,7 @@ public class PersistentEnumDataType<T extends Enum<T>> extends AbstractPersisten
      *
      * @param enumClass The class of the enum.
      */
-    public PersistentEnumDataType(@Nonnull final Class<T> enumClass) {
+    public PersistentEnumDataType(@NotNull final Class<T> enumClass) {
         super(String.class, enumClass);
         this.defaultValue = null;
         this.useDefault = false;
@@ -31,7 +31,7 @@ public class PersistentEnumDataType<T extends Enum<T>> extends AbstractPersisten
      *                     return if the raw value is null or invalid.
      */
     @SuppressWarnings("unchecked")
-    public PersistentEnumDataType(@Nonnull final T defaultValue) {
+    public PersistentEnumDataType(@NotNull final T defaultValue) {
         super(String.class, (Class<T>) defaultValue.getClass());
         this.defaultValue = defaultValue;
         this.useDefault = true;
@@ -40,20 +40,20 @@ public class PersistentEnumDataType<T extends Enum<T>> extends AbstractPersisten
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
-    public String toPrimitive(@Nonnull final T instance,
-                              @Nonnull final PersistentDataAdapterContext adapter) {
+    public String toPrimitive(@NotNull final T instance,
+                              @NotNull final PersistentDataAdapterContext adapter) {
         return instance.name();
     }
 
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
-    public T fromPrimitive(@Nonnull final String raw,
-                           @Nonnull final PersistentDataAdapterContext adapter) {
+    public T fromPrimitive(@NotNull final String raw,
+                           @NotNull final PersistentDataAdapterContext adapter) {
         return this.useDefault ?
             EnumUtils.getEnum(this.complexClass, raw, this.defaultValue) :
             Objects.requireNonNull(EnumUtils.getEnum(this.complexClass, raw),

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/pdc/PersistentMapDataType.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/pdc/PersistentMapDataType.java
@@ -3,11 +3,11 @@ package vg.civcraft.mc.civmodcore.pdc;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.bukkit.NamespacedKey;
 import org.bukkit.persistence.PersistentDataAdapterContext;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This class enables easier encoding and decoding of maps.
@@ -17,8 +17,8 @@ public abstract class PersistentMapDataType<K, V> implements PersistentDataType<
     private final PersistentDataType<NamespacedKey, K> keyEncoder;
     private final PersistentDataType<?, V> valueEncoder;
 
-    public PersistentMapDataType(@Nonnull final PersistentDataType<NamespacedKey, K> keyEncoder,
-                                 @Nonnull final PersistentDataType<?, V> valueEncoder) {
+    public PersistentMapDataType(@NotNull final PersistentDataType<NamespacedKey, K> keyEncoder,
+                                 @NotNull final PersistentDataType<?, V> valueEncoder) {
         this.keyEncoder = Objects.requireNonNull(keyEncoder);
         this.valueEncoder = Objects.requireNonNull(valueEncoder);
     }
@@ -26,7 +26,7 @@ public abstract class PersistentMapDataType<K, V> implements PersistentDataType<
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
     public Class<PersistentDataContainer> getPrimitiveType() {
         return PersistentDataContainer.class;
@@ -36,7 +36,7 @@ public abstract class PersistentMapDataType<K, V> implements PersistentDataType<
      * {@inheritDoc}
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @Nonnull
+    @NotNull
     @Override
     public Class<Map<K, V>> getComplexType() {
         return (Class<Map<K, V>>) ((Class<? extends Map>) Map.class);
@@ -46,16 +46,16 @@ public abstract class PersistentMapDataType<K, V> implements PersistentDataType<
      * @param initialSize Initial size of the map.
      * @return Returns a new map that's used in {@link #fromPrimitive(PersistentDataContainer, PersistentDataAdapterContext)}.
      */
-    @Nonnull
+    @NotNull
     protected abstract Map<K, V> newMap(int initialSize);
 
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
-    public PersistentDataContainer toPrimitive(@Nonnull final Map<K, V> map,
-                                               @Nonnull final PersistentDataAdapterContext adapter) {
+    public PersistentDataContainer toPrimitive(@NotNull final Map<K, V> map,
+                                               @NotNull final PersistentDataAdapterContext adapter) {
         final var pdc = adapter.newPersistentDataContainer();
         map.forEach((key, value) -> pdc.set(
             this.keyEncoder.toPrimitive(key, adapter),
@@ -66,10 +66,10 @@ public abstract class PersistentMapDataType<K, V> implements PersistentDataType<
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
-    public Map<K, V> fromPrimitive(@Nonnull final PersistentDataContainer pdc,
-                                   @Nonnull final PersistentDataAdapterContext adapter) {
+    public Map<K, V> fromPrimitive(@NotNull final PersistentDataContainer pdc,
+                                   @NotNull final PersistentDataAdapterContext adapter) {
         final Set<NamespacedKey> keys = pdc.getKeys();
         final Map<K, V> map = newMap(keys.size());
         keys.forEach((key) -> map.put(

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/pdc/extensions/PersistentDataContainerExtensions.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/pdc/extensions/PersistentDataContainerExtensions.java
@@ -4,13 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nonnull;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import org.bukkit.NamespacedKey;
 import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.nbt.NBTType;
 
 /**
@@ -22,8 +22,8 @@ public final class PersistentDataContainerExtensions {
      * @param self The PersistentDataContainer to get the internal NBT of.
      * @return Returns the PDC's inner-map.
      */
-    @Nonnull
-    public static Map<String, Tag> getRaw(@Nonnull final PersistentDataContainer self) {
+    @NotNull
+    public static Map<String, Tag> getRaw(@NotNull final PersistentDataContainer self) {
         return ((CraftPersistentDataContainer) self).getRaw();
     }
 
@@ -31,7 +31,7 @@ public final class PersistentDataContainerExtensions {
      * @param self The PersistentDataContainer to get the size of.
      * @return Returns the PDC's size.
      */
-    public static int size(@Nonnull final PersistentDataContainer self) {
+    public static int size(@NotNull final PersistentDataContainer self) {
         return getRaw(self).size();
     }
 
@@ -40,8 +40,8 @@ public final class PersistentDataContainerExtensions {
      * @param key  The key of the list.
      * @return Returns true if a list is present at that key.
      */
-    public static boolean hasList(@Nonnull final PersistentDataContainer self,
-                                  @Nonnull final NamespacedKey key) {
+    public static boolean hasList(@NotNull final PersistentDataContainer self,
+                                  @NotNull final NamespacedKey key) {
         final var found = getRaw(self).get(key.toString());
         return found != null && found.getId() == NBTType.LIST;
     }
@@ -53,9 +53,9 @@ public final class PersistentDataContainerExtensions {
      * @param <P>  The primitive type the list elements type.
      * @param <C>  The complex type of the list elements type.
      */
-    public static <P, C> List<C> getList(@Nonnull final PersistentDataContainer self,
-                                         @Nonnull final NamespacedKey key,
-                                         @Nonnull final PersistentDataType<P, C> type) {
+    public static <P, C> List<C> getList(@NotNull final PersistentDataContainer self,
+                                         @NotNull final NamespacedKey key,
+                                         @NotNull final PersistentDataType<P, C> type) {
         final var pdc = (CraftPersistentDataContainer) self;
         final var found = pdc.getRaw().get(key.toString());
         if (!(found instanceof ListTag tagList)) {
@@ -79,10 +79,10 @@ public final class PersistentDataContainerExtensions {
      * @param <C>  The complex type of the list elements type.
      * @param list The list to set.
      */
-    public static <P, C> void setList(@Nonnull final PersistentDataContainer self,
-                                      @Nonnull final NamespacedKey key,
-                                      @Nonnull final PersistentDataType<P, C> type,
-                                      @Nonnull final List<C> list) {
+    public static <P, C> void setList(@NotNull final PersistentDataContainer self,
+                                      @NotNull final NamespacedKey key,
+                                      @NotNull final PersistentDataType<P, C> type,
+                                      @NotNull final List<C> list) {
         final var pdc = (CraftPersistentDataContainer) self;
         final var typeRegistry = pdc.getDataTagTypeRegistry();
         final var result = new ListTag();

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/CivLogger.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/CivLogger.java
@@ -4,19 +4,19 @@ import com.destroystokyo.paper.utils.PaperPluginLogger;
 import java.util.Objects;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.PluginClassLoader;
+import org.jetbrains.annotations.NotNull;
 
 public final class CivLogger extends Logger {
 
     private final String prefix;
 
-    private CivLogger(@Nonnull final Logger logger, @Nonnull final String prefix) {
+    private CivLogger(@NotNull final Logger logger, @NotNull final String prefix) {
         super(logger.getName(), logger.getResourceBundleName());
         setParent(logger);
         this.prefix = Objects.requireNonNull(prefix);
@@ -35,8 +35,8 @@ public final class CivLogger extends Logger {
      * @param clazz The class to base the logger on.
      * @return Returns a new civ logger.
      */
-    @Nonnull
-    public static CivLogger getLogger(@Nonnull final Class<?> clazz) {
+    @NotNull
+    public static CivLogger getLogger(@NotNull final Class<?> clazz) {
         return INTERNAL_generateLogger(clazz.getClassLoader(), clazz);
     }
 
@@ -50,14 +50,14 @@ public final class CivLogger extends Logger {
      * @param targetClass The target class to log about.
      * @return Returns a new civ logger.
      */
-    @Nonnull
-    public static CivLogger getLogger(@Nonnull final Class<? extends Plugin> pluginClass,
-                                      @Nonnull final Class<?> targetClass) {
+    @NotNull
+    public static CivLogger getLogger(@NotNull final Class<? extends Plugin> pluginClass,
+                                      @NotNull final Class<?> targetClass) {
         return INTERNAL_generateLogger(pluginClass.getClassLoader(), targetClass);
     }
 
-    private static CivLogger INTERNAL_generateLogger(@Nonnull final ClassLoader loader,
-                                                     @Nonnull final Class<?> clazz) {
+    private static CivLogger INTERNAL_generateLogger(@NotNull final ClassLoader loader,
+                                                     @NotNull final Class<?> clazz) {
         if (loader instanceof final PluginClassLoader pluginClassLoader) {
             final var plugin = pluginClassLoader.getPlugin();
             if (plugin != null) {

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/DependencyGlue.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/DependencyGlue.java
@@ -2,8 +2,6 @@ package vg.civcraft.mc.civmodcore.utilities;
 
 import java.util.Objects;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
@@ -14,6 +12,8 @@ import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.event.server.ServerLoadEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Class designed to make creating glue classes easier, particularly with soft dependencies where your plugins may use
@@ -35,7 +35,7 @@ public abstract class DependencyGlue implements Listener {
      * @param plugin         The host plugin that requires the glued dependency. Must be enabled.
      * @param dependencyName The name of the plugin you wish to glue.
      */
-    protected DependencyGlue(@Nonnull final Plugin plugin, @Nonnull final String dependencyName) {
+    protected DependencyGlue(@NotNull final Plugin plugin, @NotNull final String dependencyName) {
         this.pluginManager = Bukkit.getPluginManager();
         this.plugin = Objects.requireNonNull(plugin);
         this.logger = CivLogger.getLogger(plugin.getClass(), getClass());
@@ -47,7 +47,7 @@ public abstract class DependencyGlue implements Listener {
      *
      * @return Returns the glue's plugin name.
      */
-    @Nonnull
+    @NotNull
     public String getDependencyName() {
         return this.dependencyName;
     }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/KeyedUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/KeyedUtils.java
@@ -1,9 +1,9 @@
 package vg.civcraft.mc.civmodcore.utilities;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility class to make dealing with namespace keys easier.
@@ -33,8 +33,8 @@ public final class KeyedUtils {
      *                                  combined length is longer than 256.
      */
     @SuppressWarnings("deprecation")
-    @Nonnull
-    public static NamespacedKey fromParts(@Nonnull final String namespace, @Nonnull final String key) {
+    @NotNull
+    public static NamespacedKey fromParts(@NotNull final String namespace, @NotNull final String key) {
         return new NamespacedKey(namespace, key);
     }
 
@@ -65,8 +65,8 @@ public final class KeyedUtils {
      * @return Returns a new {@link NamespacedKey} for testing purposes.
      */
     @SuppressWarnings("deprecation")
-    @Nonnull
-    public static NamespacedKey testKey(@Nonnull final String key) {
+    @NotNull
+    public static NamespacedKey testKey(@NotNull final String key) {
         return new NamespacedKey("test", key);
     }
 

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/MoreCollectionUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/MoreCollectionUtils.java
@@ -8,11 +8,11 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.collections4.list.LazyList;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Utility class that fills in the gaps of {@link CollectionUtils}.
@@ -127,7 +127,7 @@ public final class MoreCollectionUtils {
      * @param size           The size to ensure.
      * @param defaultElement The element to place into the collection if expanded.
      */
-    public static <T> void ensureMinimumSize(@Nonnull final Collection<T> collection,
+    public static <T> void ensureMinimumSize(@NotNull final Collection<T> collection,
                                              final int size,
                                              final T defaultElement) {
         if (size < 0 || size < collection.size()) {

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/NullUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/NullUtils.java
@@ -1,6 +1,6 @@
 package vg.civcraft.mc.civmodcore.utilities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Protonull
@@ -49,7 +49,7 @@ public final class NullUtils {
      * @param object The object that isn't null.
      * @return Returns the object highlighted as non-null.
      */
-    @Nonnull
+    @NotNull
     public static <T> T isNotNull(final T object) {
         return object;
     }

--- a/plugins/combattagplus-paper/src/main/java/net/minelink/ctplus/listener/PlayerListener.java
+++ b/plugins/combattagplus-paper/src/main/java/net/minelink/ctplus/listener/PlayerListener.java
@@ -1,7 +1,6 @@
 package net.minelink.ctplus.listener;
 
 import java.util.UUID;
-import javax.annotation.Nullable;
 
 import net.minelink.ctplus.CombatTagPlus;
 import net.minelink.ctplus.Tag;
@@ -31,6 +30,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 public final class PlayerListener implements Listener {
 

--- a/plugins/combattagplus-paper/src/main/java/net/minelink/ctplus/listener/TagListener.java
+++ b/plugins/combattagplus-paper/src/main/java/net/minelink/ctplus/listener/TagListener.java
@@ -27,8 +27,8 @@ import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.projectiles.ProjectileSource;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.Objects;
 

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/commands/FMCommandManager.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/commands/FMCommandManager.java
@@ -4,8 +4,8 @@ import co.aikar.commands.BukkitCommandCompletionContext;
 import co.aikar.commands.CommandCompletions;
 import com.github.igotyou.FactoryMod.FactoryMod;
 import com.github.igotyou.FactoryMod.eggs.IFactoryEgg;
-import javax.annotation.Nonnull;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.commands.CommandManager;
 
 public class FMCommandManager extends CommandManager {
@@ -25,7 +25,7 @@ public class FMCommandManager extends CommandManager {
     }
 
     @Override
-    public void registerCompletions(@Nonnull CommandCompletions<BukkitCommandCompletionContext> completions) {
+    public void registerCompletions(@NotNull CommandCompletions<BukkitCommandCompletionContext> completions) {
         super.registerCompletions(completions);
         completions.registerCompletion("FM_Factories", (context) -> FactoryMod.getInstance().getManager().getAllFactoryEggs().stream().map(
             IFactoryEgg::getName).toList());

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/EffectFeasibility.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/EffectFeasibility.java
@@ -1,6 +1,6 @@
 package com.github.igotyou.FactoryMod.recipes;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Captures the feasibility of applying a recipe effect along with an optional reason string.

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintBookRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintBookRecipe.java
@@ -17,10 +17,9 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
-
-import javax.annotation.Nullable;
 
 public class PrintBookRecipe extends PrintingPressRecipe {
 

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/MultiInventoryWrapper.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/MultiInventoryWrapper.java
@@ -8,7 +8,6 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -147,7 +146,7 @@ public class MultiInventoryWrapper implements Inventory {
     }
 
     @Override
-    public @org.checkerframework.checker.nullness.qual.Nullable ItemStack @NonNull [] getContents() {
+    public @Nullable ItemStack @NotNull [] getContents() {
         ItemStack[] combinedContents = new ItemStack[size];
         for (int inv = 0, slot = 0; inv < wrapped.length; inv++) {
             ItemStack[] sub = wrapped[inv].getContents();

--- a/plugins/hiddenore-paper/src/main/java/com/github/devotedmc/hiddenore/util/FakePlayer.java
+++ b/plugins/hiddenore-paper/src/main/java/com/github/devotedmc/hiddenore/util/FakePlayer.java
@@ -25,8 +25,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.TeleportFlag;
@@ -108,6 +106,7 @@ import org.bukkit.util.BoundingBox;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jetbrains.annotations.UnmodifiableView;
@@ -659,7 +658,7 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public boolean hasLineOfSight(@Nonnull Location location) {
+    public boolean hasLineOfSight(@NotNull Location location) {
         return false;
     }
 
@@ -749,7 +748,7 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public void registerAttribute(@Nonnull Attribute attribute) {
+    public void registerAttribute(@NotNull Attribute attribute) {
 
     }
 
@@ -1360,7 +1359,7 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public @Nonnull Identity identity() {
+    public @NotNull Identity identity() {
         return Player.super.identity();
     }
 
@@ -1370,7 +1369,7 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public @Nonnull Component displayName() {
+    public @NotNull Component displayName() {
         return Component.text("Spoof");
     }
 
@@ -1612,7 +1611,7 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public boolean breakBlock(@Nonnull Block block) {
+    public boolean breakBlock(@NotNull Block block) {
         return false;
     }
 
@@ -2316,7 +2315,7 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public @Nonnull EquipmentSlot getHandRaised() {
+    public @NotNull EquipmentSlot getHandRaised() {
         return null;
     }
 
@@ -2570,7 +2569,7 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public void sendBlockDamage(@Nonnull Location location, float f) {
+    public void sendBlockDamage(@NotNull Location location, float f) {
 
     }
 
@@ -2921,9 +2920,9 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public void sendSignChange(@Nonnull Location location,
+    public void sendSignChange(@NotNull Location location,
                                @Nullable String[] strings,
-                               @Nonnull DyeColor dyeColor, boolean bl)
+                               @NotNull DyeColor dyeColor, boolean bl)
         throws IllegalArgumentException {
 
     }
@@ -2950,7 +2949,7 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public @Nonnull Locale locale() {
+    public @NotNull Locale locale() {
         return Locale.ENGLISH;
     }
 
@@ -3574,7 +3573,7 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public @Nonnull Set<Player> getTrackedPlayers() {
+    public @NotNull Set<Player> getTrackedPlayers() {
         return null;
     }
 
@@ -3806,14 +3805,14 @@ public class FakePlayer implements Player {
     }
 
     @Override
-    public void setResourcePack(@Nonnull String string,
-                                @Nonnull String string2, boolean bl) {
+    public void setResourcePack(@NotNull String string,
+                                @NotNull String string2, boolean bl) {
 
     }
 
     @Override
-    public void setResourcePack(@Nonnull String string,
-                                @Nonnull String string2, boolean bl,
+    public void setResourcePack(@NotNull String string,
+                                @NotNull String string2, boolean bl,
                                 @Nullable Component component) {
 
     }

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/BulkExchangeRule.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/BulkExchangeRule.java
@@ -2,8 +2,6 @@ package com.untamedears.itemexchange.rules;
 
 import com.untamedears.itemexchange.ItemExchangeConfig;
 import com.untamedears.itemexchange.rules.interfaces.ExchangeData;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -15,6 +13,8 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.component.CustomData;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.MetaUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
@@ -24,7 +24,7 @@ public record BulkExchangeRule(List<ExchangeRule> rules) implements ExchangeData
     public static final String BULK_KEY = "BulkExchangeRule";
     public static final String RULES_KEY = "rules";
 
-    public BulkExchangeRule(@Nonnull final List<ExchangeRule> rules) {
+    public BulkExchangeRule(@NotNull final List<ExchangeRule> rules) {
         this.rules = Objects.requireNonNull(rules);
     }
 
@@ -34,7 +34,7 @@ public record BulkExchangeRule(List<ExchangeRule> rules) implements ExchangeData
     }
 
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         nbt.setCompoundArray(RULES_KEY, this.rules.stream()
             .map((rule) -> {
                 final var ruleNBT = new NBTCompound();
@@ -44,8 +44,8 @@ public record BulkExchangeRule(List<ExchangeRule> rules) implements ExchangeData
             .toArray(NBTCompound[]::new));
     }
 
-    @Nonnull
-    public static BulkExchangeRule fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static BulkExchangeRule fromNBT(@NotNull final NBTCompound nbt) {
         return new BulkExchangeRule(Arrays.stream(nbt.getCompoundArray(RULES_KEY))
             .map(ExchangeRule::fromNBT)
             .collect(Collectors.toCollection(ArrayList::new)));

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/ExchangeRule.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/ExchangeRule.java
@@ -9,7 +9,6 @@ import com.untamedears.itemexchange.rules.modifiers.DisplayNameModifier;
 import com.untamedears.itemexchange.rules.modifiers.LoreModifier;
 import com.untamedears.itemexchange.utility.ModifierStorage;
 import com.untamedears.itemexchange.utility.Utilities;
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,6 +24,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.InventoryUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.nbt.NBTSerialization;
@@ -209,7 +209,7 @@ public final class ExchangeRule implements ExchangeData {
     }
 
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         nbt.setInt(VERSION_KEY, 4);
         nbt.setString(TYPE_KEY, this.type.name());
         nbt.setString(MATERIAL_KEY, this.material.name());
@@ -224,8 +224,8 @@ public final class ExchangeRule implements ExchangeData {
             .toArray(NBTCompound[]::new));
     }
 
-    @Nonnull
-    public static ExchangeRule fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static ExchangeRule fromNBT(@NotNull final NBTCompound nbt) {
         final var rule = new ExchangeRule();
         rule.type = EnumUtils.getEnum(Type.class, nbt.getString(TYPE_KEY));
         rule.material = EnumUtils.getEnum(Material.class, nbt.getString(MATERIAL_KEY));

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/BookModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/BookModifier.java
@@ -8,13 +8,13 @@ import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import javax.annotation.Nonnull;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.EnumUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.BookMeta.Generation;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.nbt.NBTType;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 
@@ -89,7 +89,7 @@ public final class BookModifier extends ModifierData {
     }
 
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         if (hasTitle()) {
             nbt.setString(TITLE_KEY, this.title);
         }
@@ -105,8 +105,8 @@ public final class BookModifier extends ModifierData {
         }
     }
 
-    @Nonnull
-    public static BookModifier fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static BookModifier fromNBT(@NotNull final NBTCompound nbt) {
         final var modifier = new BookModifier();
         if (nbt.hasKeyOfType(TITLE_KEY, NBTType.STRING)) {
             modifier.setTitle(nbt.getString(TITLE_KEY));

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/DamageableModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/DamageableModifier.java
@@ -15,11 +15,11 @@ import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.ModifierHandler;
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.Nonnull;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 
@@ -77,12 +77,12 @@ public final class DamageableModifier extends ModifierData {
     }
 
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         nbt.setInt(DAMAGE_KEY, getDamage());
     }
 
-    @Nonnull
-    public static DamageableModifier fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static DamageableModifier fromNBT(@NotNull final NBTCompound nbt) {
         final var modifier = new DamageableModifier();
         modifier.setDamage(nbt.getInt(DAMAGE_KEY));
         return modifier;

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/DisplayNameModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/DisplayNameModifier.java
@@ -10,12 +10,12 @@ import com.untamedears.itemexchange.commands.SetCommand;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.ModifierHandler;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 
 @CommandAlias(SetCommand.ALIAS)
@@ -59,7 +59,7 @@ public final class DisplayNameModifier extends ModifierData {
     }
 
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         if (hasDisplayName()) {
             nbt.setString(DISPLAY_NAME_KEY, getDisplayName());
         } else {
@@ -67,8 +67,8 @@ public final class DisplayNameModifier extends ModifierData {
         }
     }
 
-    @Nonnull
-    public static DisplayNameModifier fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static DisplayNameModifier fromNBT(@NotNull final NBTCompound nbt) {
         final var modifier = new DisplayNameModifier();
         modifier.setDisplayName(nbt.getString(DISPLAY_NAME_KEY));
         return modifier;

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantModifier.java
@@ -27,11 +27,11 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import org.bukkit.ChatColor;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.EnchantUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
@@ -88,7 +88,7 @@ public final class EnchantModifier extends ModifierData {
     }
 
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         nbt.setCompound(REQUIRED_KEY, NBTEncodings.encodeLeveledEnchants(getRequiredEnchants()));
         nbt.setStringArray(EXCLUDED_KEY, getExcludedEnchants().stream()
             .map(KeyedUtils::getString)
@@ -97,8 +97,8 @@ public final class EnchantModifier extends ModifierData {
         nbt.setBoolean(UNLISTED_KEY, isAllowingUnlistedEnchants());
     }
 
-    @Nonnull
-    public static EnchantModifier fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static EnchantModifier fromNBT(@NotNull final NBTCompound nbt) {
         final var modifier = new EnchantModifier();
         modifier.setRequiredEnchants(NBTEncodings.decodeLeveledEnchants(nbt.getCompound(REQUIRED_KEY)));
         modifier.setExcludedEnchants(Arrays.stream(nbt.getStringArray(EXCLUDED_KEY))

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantStorageModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantStorageModifier.java
@@ -11,12 +11,12 @@ import com.untamedears.itemexchange.utility.NBTEncodings;
 import com.untamedears.itemexchange.utility.Utilities;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.commons.collections4.MapUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.EnchantUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 import vg.civcraft.mc.civmodcore.utilities.MoreMapUtils;
@@ -72,12 +72,12 @@ public final class EnchantStorageModifier extends ModifierData {
     }
 
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         nbt.setCompound(ENCHANTS_KEY, NBTEncodings.encodeLeveledEnchants(getEnchants()));
     }
 
-    @Nonnull
-    public static EnchantStorageModifier fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static EnchantStorageModifier fromNBT(@NotNull final NBTCompound nbt) {
         final var modifier = new EnchantStorageModifier();
         modifier.setEnchants(NBTEncodings.decodeLeveledEnchants(nbt.getCompound(ENCHANTS_KEY)));
         return modifier;

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/LoreModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/LoreModifier.java
@@ -15,12 +15,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import org.apache.commons.collections4.CollectionUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
@@ -64,7 +64,7 @@ public final class LoreModifier extends ModifierData {
     }
 
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         if (this.lore == null) {
             nbt.remove(LORE_KEY);
         } else {
@@ -72,8 +72,8 @@ public final class LoreModifier extends ModifierData {
         }
     }
 
-    @Nonnull
-    public static LoreModifier fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static LoreModifier fromNBT(@NotNull final NBTCompound nbt) {
         final var modifier = new LoreModifier();
         modifier.setLore(MoreCollectionUtils.collect(ArrayList::new, nbt.getStringArray(LORE_KEY)));
         return modifier;

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/PotionModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/PotionModifier.java
@@ -8,7 +8,6 @@ import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.NBTEncodings;
 import com.untamedears.itemexchange.utility.Utilities;
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionType;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.PotionUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 import vg.civcraft.mc.civmodcore.utilities.NullUtils;
@@ -74,14 +74,14 @@ public final class PotionModifier extends ModifierData {
     }
 
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         nbt.setCompound(BASE_KEY, NBTEncodings.encodePotionData(this.base));
         nbt.setCompoundArray(EFFECTS_KEY, getEffects().stream()
             .map(NBTEncodings::encodePotionEffect)
             .toArray(NBTCompound[]::new));
     }
 
-    public static PotionModifier fromNBT(@Nonnull final NBTCompound nbt) {
+    public static PotionModifier fromNBT(@NotNull final NBTCompound nbt) {
         final var modifier = new PotionModifier();
         PotionType type = NBTEncodings.decodePotionData(nbt.getCompound(BASE_KEY));
         if (type == null) {

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/RepairModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/RepairModifier.java
@@ -16,12 +16,12 @@ import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.ModifierHandler;
 import java.util.List;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Repairable;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 
 /**
@@ -74,12 +74,12 @@ public final class RepairModifier extends ModifierData {
     }
 
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         nbt.setInt(LEVEL_KEY, getRepairCost());
     }
 
-    @Nonnull
-    public static RepairModifier fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static RepairModifier fromNBT(@NotNull final NBTCompound nbt) {
         final var modifier = new RepairModifier();
         modifier.setRepairCost(nbt.getInt(LEVEL_KEY));
         return modifier;

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/_ExampleModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/_ExampleModifier.java
@@ -7,9 +7,9 @@ import com.untamedears.itemexchange.rules.interfaces.ExchangeData;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import java.util.List;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.NotImplementedException;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.nbt.NBTSerializable;
 import vg.civcraft.mc.civmodcore.nbt.NBTSerializationException;
@@ -69,7 +69,7 @@ public final class _ExampleModifier extends ModifierData {
      * @throws NBTSerializationException This is thrown if the implementation has a fatal error serializing.
      */
     @Override
-    public void toNBT(@Nonnull final NBTCompound nbt) {
+    public void toNBT(@NotNull final NBTCompound nbt) {
         throw new NotImplementedException("Please implement me on your class!");
     }
 
@@ -80,8 +80,8 @@ public final class _ExampleModifier extends ModifierData {
      *            {@link NBTSerializationException} if it is.
      * @throws NBTSerializationException This is thrown if the implementation has a fatal error deserializing.
      */
-    @Nonnull
-    public static NBTSerializable fromNBT(@Nonnull final NBTCompound nbt) {
+    @NotNull
+    public static NBTSerializable fromNBT(@NotNull final NBTCompound nbt) {
         final var modifier = new _ExampleModifier();
         // Something here
         return modifier;

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/ModifierStorage.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/ModifierStorage.java
@@ -9,8 +9,8 @@ import java.util.Objects;
 import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A storage method for modifiers that puts significance on the modifier's class.
@@ -68,7 +68,7 @@ public final class ModifierStorage implements Iterable<ModifierData> {
      * @return Returns a cast modifier to the given type, or null.
      */
     @Nullable
-    public <T extends ModifierData> T get(@Nonnull final Class<T> clazz) {
+    public <T extends ModifierData> T get(@NotNull final Class<T> clazz) {
         return (T) this.map.getInstance(Objects.requireNonNull(clazz));
     }
 
@@ -81,7 +81,7 @@ public final class ModifierStorage implements Iterable<ModifierData> {
      */
     @Nullable
     @SuppressWarnings("unchecked")
-    public <T extends ModifierData> T get(@Nonnull final T instance) {
+    public <T extends ModifierData> T get(@NotNull final T instance) {
         return get((Class<T>) instance.getClass());
     }
 
@@ -94,10 +94,10 @@ public final class ModifierStorage implements Iterable<ModifierData> {
      * @param supplier A supplier to create a new modifier. MUST NOT RETURN NULL!
      * @return Returns a cast modifier to the given type, or null if the given supplier returned null.
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings("unchecked")
-    public <T extends ModifierData> T getOrDefault(@Nonnull final Class<T> clazz,
-                                                   @Nonnull final NonNullSupplier<T> supplier) {
+    public <T extends ModifierData> T getOrDefault(@NotNull final Class<T> clazz,
+                                                   @NotNull final NonNullSupplier<T> supplier) {
         return (T) this.map.computeIfAbsent(Objects.requireNonNull(clazz), (_clazz) -> supplier.get());
     }
 
@@ -110,10 +110,10 @@ public final class ModifierStorage implements Iterable<ModifierData> {
      * @param supplier A supplier to create a new modifier. MUST NOT RETURN NULL!
      * @return Returns a cast modifier to the given type, or null if the given supplier returned null.
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings("unchecked")
-    public <T extends ModifierData> T getOrDefault(@Nonnull final T instance,
-                                                   @Nonnull final NonNullSupplier<T> supplier) {
+    public <T extends ModifierData> T getOrDefault(@NotNull final T instance,
+                                                   @NotNull final NonNullSupplier<T> supplier) {
         return getOrDefault((Class<T>) instance.getClass(), supplier);
     }
 
@@ -124,7 +124,7 @@ public final class ModifierStorage implements Iterable<ModifierData> {
      * @return Returns any previous modifier that was stored, not null.
      */
     @Nullable
-    public ModifierData put(@Nonnull final ModifierData instance) {
+    public ModifierData put(@NotNull final ModifierData instance) {
         return this.map.put(instance.getClass(), instance);
     }
 
@@ -155,19 +155,19 @@ public final class ModifierStorage implements Iterable<ModifierData> {
         return "ModifierStorage" + this.map.values();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Iterator<ModifierData> iterator() {
         return this.map.values().iterator();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Spliterator<ModifierData> spliterator() {
         return this.map.values().spliterator();
     }
 
-    @Nonnull
+    @NotNull
     public Stream<ModifierData> stream() {
         return this.map.values().stream()
             .filter(Objects::nonNull)
@@ -175,7 +175,7 @@ public final class ModifierStorage implements Iterable<ModifierData> {
     }
 
     @Override
-    public void forEach(@Nonnull final Consumer<? super ModifierData> action) {
+    public void forEach(@NotNull final Consumer<? super ModifierData> action) {
         stream().forEachOrdered(action);
     }
 

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/Utilities.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/Utilities.java
@@ -6,7 +6,6 @@ import com.untamedears.itemexchange.ItemExchangeConfig;
 import com.untamedears.itemexchange.ItemExchangePlugin;
 import com.untamedears.itemexchange.rules.BulkExchangeRule;
 import com.untamedears.itemexchange.rules.ExchangeRule;
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,6 +26,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionType;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.InventoryUtils;
 import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 import vg.civcraft.mc.civmodcore.utilities.NullUtils;
@@ -73,7 +73,7 @@ public final class Utilities {
      * @param inventory The inventory to give the items to. It must have a location, like a chest inventory.
      * @param items     The items to give to the inventory.
      */
-    public static void giveItemsOrDrop(@Nonnull final Inventory inventory, @Nonnull final ItemStack... items) {
+    public static void giveItemsOrDrop(@NotNull final Inventory inventory, @NotNull final ItemStack... items) {
         Preconditions.checkArgument(InventoryUtils.isValidInventory(inventory));
         Preconditions.checkArgument(WorldUtils.isValidLocation(inventory.getLocation()));
         Preconditions.checkArgument(ArrayUtils.isNotEmpty(items));

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/functional/NonNullSupplier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/functional/NonNullSupplier.java
@@ -1,7 +1,7 @@
 package com.untamedears.itemexchange.utility.functional;
 
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This is a version of Supplier with the contract of not returning null.
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
 @FunctionalInterface
 public interface NonNullSupplier<T> extends Supplier<T> {
 
-    @Nonnull
+    @NotNull
     @Override
     T get();
 

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/SnitchManager.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/SnitchManager.java
@@ -14,12 +14,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 
 import com.untamedears.jukealert.model.actions.ActionCacheState;
 import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerAction;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.world.locations.SparseQuadTree;
 import vg.civcraft.mc.civmodcore.world.locations.chunkmeta.CacheState;
 import vg.civcraft.mc.civmodcore.world.locations.chunkmeta.api.SingleBlockAPIView;
@@ -118,7 +118,7 @@ public class SnitchManager {
      *
      * @param snitch Snitch to remove
      */
-    public void removeSnitch(@Nonnull final Snitch snitch) {
+    public void removeSnitch(@NotNull final Snitch snitch) {
         snitch.setCacheState(CacheState.DELETED);
         this.api.remove(snitch);
         final SparseQuadTree<SnitchQTEntry> quadTree = getQuadTreeFor(snitch.getLocation());

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/commands/ListCommand.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/commands/ListCommand.java
@@ -17,11 +17,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import net.md_5.bungee.api.ChatColor;
 import org.apache.commons.lang3.ArrayUtils;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
@@ -89,7 +89,7 @@ public class ListCommand extends BaseCommand {
         private final Snitch snitch;
         private final long timeUntilCulling;
 
-        public SnitchCache(@Nonnull final Snitch snitch,
+        public SnitchCache(@NotNull final Snitch snitch,
                            final long timeUntilCulling) {
             this.snitch = snitch;
             this.timeUntilCulling = timeUntilCulling;

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/database/JukeAlertDAO.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/database/JukeAlertDAO.java
@@ -33,8 +33,6 @@ import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.bukkit.Bukkit;
@@ -43,6 +41,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.EntityType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.CivModCorePlugin;
 import vg.civcraft.mc.civmodcore.dao.ManagedDatasource;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
@@ -59,7 +59,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
 
     public static final int NOT_YET_INSERTED_ID = -1;
 
-    public JukeAlertDAO(@Nonnull final ManagedDatasource datasource) {
+    public JukeAlertDAO(@NotNull final ManagedDatasource datasource) {
         super(CivLogger.getLogger(JukeAlertDAO.class), Objects.requireNonNull(datasource));
     }
 
@@ -262,7 +262,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
     // ------------------------------------------------------------
 
     @Override
-    public void insert(@Nonnull final Snitch snitch) {
+    public void insert(@NotNull final Snitch snitch) {
         if (snitch.getId() != NOT_YET_INSERTED_ID) {
             this.logger.warning("Skipping snitch insert of [" + snitch + "] because its id is already set :s");
             return;
@@ -299,7 +299,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
     }
 
     @Override
-    public void update(@Nonnull final Snitch snitch) {
+    public void update(@NotNull final Snitch snitch) {
         if (snitch.getId() == NOT_YET_INSERTED_ID) {
             this.logger.warning("Skipping snitch update of [" + snitch + "] because its id is invalid!");
             return;
@@ -324,7 +324,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
     }
 
     @Override
-    public void delete(@Nonnull final Snitch snitch) {
+    public void delete(@NotNull final Snitch snitch) {
         if (snitch.getId() == NOT_YET_INSERTED_ID) {
             this.logger.warning("Skipping snitch deletion of [" + snitch + "] because its id is invalid!");
             return;
@@ -340,7 +340,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
     }
 
     @Override
-    public void loadAll(@Nonnull final Consumer<Snitch> callback) {
+    public void loadAll(@NotNull final Consumer<Snitch> callback) {
         final SnitchTypeManager snitchTypeManager = JukeAlert.getInstance().getSnitchConfigManager();
         final SnitchManager snitchManager = JukeAlert.getInstance().getSnitchManager();
         final WorldIDManager worldIDManager = CivModCorePlugin.getInstance().getWorldIdManager();
@@ -406,7 +406,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
     private Map<Location, Snitch> INTERNAL_snitchMap;
 
     @SuppressWarnings("unchecked")
-    @Nonnull
+    @NotNull
     public Stream<Snitch> loadSnitchesByGroupID(@Nullable final IntList groupIDs) {
         if (CollectionUtils.isEmpty(groupIDs)) {
             return Stream.empty();
@@ -454,7 +454,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
     // Actions
     // ------------------------------------------------------------
 
-    public int getOrCreateActionID(@Nonnull final String name) {
+    public int getOrCreateActionID(@NotNull final String name) {
         Objects.requireNonNull(name);
         try (final Connection connection = this.db.getConnection();
              final PreparedStatement statement = connection.prepareStatement(
@@ -499,7 +499,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
      * @param allowedActionAge The maximum allowed age (as a UNIX timestamp) for actions.
      * @param actionLimit      The maximum number of actions to load.
      */
-    public List<LoggableAction> loadLogs(@Nonnull final Snitch snitch,
+    public List<LoggableAction> loadLogs(@NotNull final Snitch snitch,
                                          final long allowedActionAge,
                                          final int actionLimit) {
         final int snitchId = snitch.getId();
@@ -551,8 +551,8 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
      * @return Returns the snitch log's new database ID.
      */
     public int insertLog(final int actionTypeID,
-                         @Nonnull final Snitch snitch,
-                         @Nonnull final LoggedActionPersistence actionData) {
+                         @NotNull final Snitch snitch,
+                         @NotNull final LoggedActionPersistence actionData) {
         try (final Connection connection = this.db.getConnection();
              final PreparedStatement statement = connection.prepareStatement(
                  "INSERT INTO ja_snitch_entries (snitch_id,type_id,uuid,x,y,z,creation_time,victim) "
@@ -584,7 +584,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
      *
      * @param log The log to delete.
      */
-    public void deleteLog(@Nonnull final LoggableAction log) {
+    public void deleteLog(@NotNull final LoggableAction log) {
         if (log.getID() == NOT_YET_INSERTED_ID) {
             return;
         }
@@ -603,7 +603,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
      *
      * @param snitch The snitch to delete all logs for.
      */
-    public void deleteAllLogsForSnitch(@Nonnull final Snitch snitch) {
+    public void deleteAllLogsForSnitch(@NotNull final Snitch snitch) {
         final int snitchID = snitch.getId();
         if (snitchID == NOT_YET_INSERTED_ID) {
             throw new IllegalArgumentException("Cannot delete logs for unknown snitch!");
@@ -625,7 +625,7 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
      * @param allowedSnitchAge The maximum allowed age (as a UNIX timestamp), all actions dated before this will be
      *                         deleted.
      */
-    public void deleteOldLogsForSnitch(@Nonnull final Snitch snitch,
+    public void deleteOldLogsForSnitch(@NotNull final Snitch snitch,
                                        final long allowedSnitchAge) {
         final int snitchID = snitch.getId();
         if (snitchID == NOT_YET_INSERTED_ID) {

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/gui/SnitchLogGUI.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/gui/SnitchLogGUI.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -21,6 +20,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.chat.Componentify;
 import vg.civcraft.mc.civmodcore.chat.dialog.Dialog;
 import vg.civcraft.mc.civmodcore.inventory.gui.Clickable;
@@ -41,15 +41,15 @@ public class SnitchLogGUI {
     private final SnitchManager snitchManager;
     private List<IClickable> buttonCache;
 
-    public SnitchLogGUI(@Nonnull final Player player,
-                        @Nonnull final Snitch snitch) {
+    public SnitchLogGUI(@NotNull final Player player,
+                        @NotNull final Snitch snitch) {
         this.player = Objects.requireNonNull(player);
         this.snitch = Objects.requireNonNull(snitch);
         this.logAppender = snitch.getAppender(SnitchLogAppender.class);
         this.snitchManager = JukeAlert.getInstance().getSnitchManager();
     }
 
-    private boolean INTERNAL_hasPermission(@Nonnull final PermissionType permission) {
+    private boolean INTERNAL_hasPermission(@NotNull final PermissionType permission) {
         return this.snitch.hasPermission(this.player.getUniqueId(), permission);
     }
 
@@ -90,7 +90,7 @@ public class SnitchLogGUI {
         if (INTERNAL_hasPermission(JukeAlertPermissionHandler.getClearLogs())) {
             return new Clickable(item) {
                 @Override
-                public void clicked(@Nonnull final Player _player) {
+                public void clicked(@NotNull final Player _player) {
                     if (INTERNAL_hasPermission(JukeAlertPermissionHandler.getClearLogs())) {
                         SnitchLogGUI.this.logAppender.deleteLogs();
                         if (SnitchLogGUI.this.buttonCache != null) {
@@ -122,7 +122,7 @@ public class SnitchLogGUI {
             .build());
         return new Clickable(item) {
             @Override
-            public void clicked(@Nonnull final Player clicker) {
+            public void clicked(@NotNull final Player clicker) {
                 clicker.sendMessage(Component.text()
                     .color(NamedTextColor.YELLOW)
                     .content("Please enter a new name for the snitch:")
@@ -211,7 +211,7 @@ public class SnitchLogGUI {
         if (INTERNAL_hasPermission(JukeAlertPermissionHandler.getToggleLevers())) {
             return new Clickable(item) {
                 @Override
-                public void clicked(@Nonnull final Player clicker) {
+                public void clicked(@NotNull final Player clicker) {
                     if (INTERNAL_hasPermission(JukeAlertPermissionHandler.getToggleLevers())) {
                         leverAppender.switchState();
                         SnitchLogGUI.this.player.sendMessage(Component.text()
@@ -267,7 +267,7 @@ public class SnitchLogGUI {
         });
         return new Clickable(item) {
             @Override
-            public void clicked(@Nonnull final Player clicker) {
+            public void clicked(@NotNull final Player clicker) {
                 ClickableInventory.forceCloseInventory(clicker);
             }
         };

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/actions/LoggedActionFactory.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/actions/LoggedActionFactory.java
@@ -26,9 +26,9 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectAVLTreeMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import javax.annotation.Nonnull;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.jetbrains.annotations.NotNull;
 
 public class LoggedActionFactory {
 
@@ -42,8 +42,8 @@ public class LoggedActionFactory {
         registerInternalProviders();
     }
 
-    public void registerProvider(@Nonnull final String identifier,
-                                 @Nonnull final LoggedActionProvider provider) {
+    public void registerProvider(@NotNull final String identifier,
+                                 @NotNull final LoggedActionProvider provider) {
         final int internal = JukeAlert.getInstance().getDAO().getOrCreateActionID(Objects.requireNonNull(identifier));
         if (internal != -1) {
             this.providers.put(identifier, Objects.requireNonNull(provider));
@@ -51,8 +51,8 @@ public class LoggedActionFactory {
         }
     }
 
-    public LoggableAction produce(@Nonnull final Snitch snitch,
-                                  @Nonnull final String identifier,
+    public LoggableAction produce(@NotNull final Snitch snitch,
+                                  @NotNull final String identifier,
                                   final UUID player,
                                   final Location location,
                                   final long time,
@@ -61,7 +61,7 @@ public class LoggedActionFactory {
         return provider == null ? null : provider.get(Objects.requireNonNull(snitch), player, location, time, victim);
     }
 
-    public int getInternalID(@Nonnull final String name) {
+    public int getInternalID(@NotNull final String name) {
         return this.identifierToInternal.getInt(Objects.requireNonNull(name));
     }
 

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/actions/LoggedActionPersistence.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/actions/LoggedActionPersistence.java
@@ -2,10 +2,10 @@ package com.untamedears.jukealert.model.actions;
 
 import java.util.Objects;
 import java.util.UUID;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Location;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * <p>Produced by actions to encapsulate saving them to the database.</p>
@@ -30,7 +30,7 @@ public final class LoggedActionPersistence {
      * @param extra     Any additional data about the action.
      */
     public LoggedActionPersistence(final long timestamp,
-                                   @Nonnull final UUID actorUUID,
+                                   @NotNull final UUID actorUUID,
                                    final int locationX,
                                    final int locationY,
                                    final int locationZ,
@@ -50,7 +50,7 @@ public final class LoggedActionPersistence {
      * @deprecated Use {@link #LoggedActionPersistence(long, UUID, int, int, int, String)} instead.
      */
     @Deprecated
-    public LoggedActionPersistence(@Nonnull final UUID actorUUID,
+    public LoggedActionPersistence(@NotNull final UUID actorUUID,
                                    final Location location,
                                    final long timestamp,
                                    final String extra) {

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/appender/DormantCullingAppender.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/appender/DormantCullingAppender.java
@@ -8,8 +8,8 @@ import com.untamedears.jukealert.model.actions.internal.DestroySnitchAction;
 import com.untamedears.jukealert.model.actions.internal.DestroySnitchAction.Cause;
 import com.untamedears.jukealert.model.appender.config.DormantCullingConfig;
 import com.untamedears.jukealert.util.JukeAlertPermissionHandler;
-import javax.annotation.Nonnull;
 import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.utilities.BukkitComparators;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 import vg.civcraft.mc.civmodcore.utilities.progress.ProgressTrackable;
@@ -66,7 +66,7 @@ public class DormantCullingAppender
     /**
      * @return Returns this snitch's expected activity status.
      */
-    @Nonnull
+    @NotNull
     public ActivityStatus getActivityStatus() {
         final long timeSinceLastRefresh = getTimeSinceLastRefresh();
         if (timeSinceLastRefresh >= this.config.getTotalLifeTime()) {
@@ -238,7 +238,7 @@ public class DormantCullingAppender
      * {@inheritDoc}
      */
     @Override
-    public int compareTo(@Nonnull final ProgressTrackable other) {
+    public int compareTo(@NotNull final ProgressTrackable other) {
         return BukkitComparators.getLocation().compare(
             ((AbstractSnitchAppender) other).getSnitch().getLocation(),
             getSnitch().getLocation());

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/appender/SnitchLogAppender.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/appender/SnitchLogAppender.java
@@ -13,8 +13,8 @@ import it.unimi.dsi.fastutil.objects.Object2IntRBTreeMap;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import javax.annotation.Nonnull;
 import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 
 public class SnitchLogAppender extends ConfigurableSnitchAppender<LimitedActionTriggerConfig> {
@@ -39,7 +39,7 @@ public class SnitchLogAppender extends ConfigurableSnitchAppender<LimitedActionT
      * @return Returns a list of actions this snitch has recorded, with certain caveats.
      * @see JukeAlertDAO#loadLogs(Snitch, long, int)
      */
-    @Nonnull
+    @NotNull
     public List<LoggableAction> getFullLogs() {
         final List<LoggableAction> actions = getSnitch().getId() == -1 ?
             new ArrayList<>(this.pendingActions.keySet()) :

--- a/plugins/kirabukkitgateway-paper/src/main/java/com/github/maxopoly/KiraBukkitGateway/impersonation/PseudoConsoleSender.java
+++ b/plugins/kirabukkitgateway-paper/src/main/java/com/github/maxopoly/KiraBukkitGateway/impersonation/PseudoConsoleSender.java
@@ -5,8 +5,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Server;
 import org.bukkit.command.ConsoleCommandSender;
@@ -17,6 +15,7 @@ import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class PseudoConsoleSender implements ConsoleCommandSender {
 
@@ -69,12 +68,12 @@ public class PseudoConsoleSender implements ConsoleCommandSender {
     }
 
     @Override
-    public void sendMessage(@Nullable final UUID uuid, @Nonnull final String message) {
+    public void sendMessage(@Nullable final UUID uuid, @NotNull final String message) {
         this.actualSender.sendMessage(uuid, message);
     }
 
     @Override
-    public void sendMessage(@Nullable final UUID uuid, @Nonnull final String[] messages) {
+    public void sendMessage(@Nullable final UUID uuid, @NotNull final String[] messages) {
         this.actualSender.sendMessage(uuid, messages);
     }
 
@@ -185,7 +184,7 @@ public class PseudoConsoleSender implements ConsoleCommandSender {
     }
 
     @Override
-    public void sendRawMessage(@Nullable final UUID uuid, @Nonnull final String s) {
+    public void sendRawMessage(@Nullable final UUID uuid, @NotNull final String s) {
 
     }
 

--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/command/CommandHandler.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/command/CommandHandler.java
@@ -2,6 +2,7 @@ package vg.civcraft.mc.namelayer.command;
 
 import co.aikar.commands.BukkitCommandCompletionContext;
 import co.aikar.commands.CommandCompletions;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.commands.CommandManager;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.NameLayerPlugin;
@@ -40,7 +41,6 @@ import vg.civcraft.mc.namelayer.command.commands.TransferGroup;
 import vg.civcraft.mc.namelayer.command.commands.UpdateName;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -89,7 +89,7 @@ public class CommandHandler extends CommandManager {
     }
 
     @Override
-    public void registerCompletions(@Nonnull CommandCompletions<BukkitCommandCompletionContext> completions) {
+    public void registerCompletions(@NotNull CommandCompletions<BukkitCommandCompletionContext> completions) {
         super.registerCompletions(completions);
         completions.registerCompletion("NL_Groups", (context) -> GroupTabCompleter.complete(context.getInput(), null, context.getPlayer()));
         completions.registerAsyncCompletion("NL_Ranks", (context) ->

--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/group/Group.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/group/Group.java
@@ -3,13 +3,13 @@ package vg.civcraft.mc.namelayer.group;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.database.GroupManagerDao;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/plugins/realisticbiomes-paper/src/main/java/com/untamedears/realisticbiomes/commands/RBCommandManager.java
+++ b/plugins/realisticbiomes-paper/src/main/java/com/untamedears/realisticbiomes/commands/RBCommandManager.java
@@ -3,14 +3,14 @@ package com.untamedears.realisticbiomes.commands;
 import co.aikar.commands.BukkitCommandCompletionContext;
 import co.aikar.commands.CommandCompletions;
 import java.util.Arrays;
-import javax.annotation.Nonnull;
 import org.bukkit.block.Biome;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.commands.CommandManager;
 
 public class RBCommandManager extends CommandManager {
 
-    public RBCommandManager(@Nonnull Plugin plugin) {
+    public RBCommandManager(@NotNull Plugin plugin) {
         super(plugin);
         init();
     }
@@ -21,7 +21,7 @@ public class RBCommandManager extends CommandManager {
     }
 
     @Override
-    public void registerCompletions(@Nonnull CommandCompletions<BukkitCommandCompletionContext> completions) {
+    public void registerCompletions(@NotNull CommandCompletions<BukkitCommandCompletionContext> completions) {
         super.registerCompletions(completions);
         completions.registerCompletion("RB_Biomes", (context) -> Arrays.stream(Biome.values()).map(Biome::name).toList());
     }

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ElytraFeaturesConfig.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ElytraFeaturesConfig.java
@@ -2,8 +2,8 @@ package com.programmerdan.minecraft.simpleadminhacks.configs;
 
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHackConfig;
-import javax.annotation.Nonnull;
 import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 
 public final class ElytraFeaturesConfig extends SimpleHackConfig {
@@ -22,15 +22,15 @@ public final class ElytraFeaturesConfig extends SimpleHackConfig {
     private int heightBuffer;
     private long heightDamageInterval;
 
-    public ElytraFeaturesConfig(@Nonnull final SimpleAdminHacks plugin,
-                                @Nonnull final ConfigurationSection base) {
+    public ElytraFeaturesConfig(@NotNull final SimpleAdminHacks plugin,
+                                @NotNull final ConfigurationSection base) {
         super(plugin, base, false);
         this.logger = CivLogger.getLogger(getClass());
         wireup(base);
     }
 
     @Override
-    protected void wireup(@Nonnull final ConfigurationSection config) {
+    protected void wireup(@NotNull final ConfigurationSection config) {
         this.disableFlight = config.getBoolean("disableFlight", false);
 
         this.disableFlightInCombat = config.getBoolean("disableFlightInCombat", false);

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/ElytraFeatures.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/ElytraFeatures.java
@@ -7,7 +7,6 @@ import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHack;
 import it.unimi.dsi.fastutil.objects.Object2ObjectAVLTreeMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import java.util.Comparator;
-import javax.annotation.Nonnull;
 import net.minelink.ctplus.CombatTagPlus;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -22,16 +21,17 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
+import org.jetbrains.annotations.NotNull;
 
 public final class ElytraFeatures extends SimpleHack<ElytraFeaturesConfig> implements Listener {
 
-    public ElytraFeatures(@Nonnull final SimpleAdminHacks plugin,
-                          @Nonnull final ElytraFeaturesConfig config) {
+    public ElytraFeatures(@NotNull final SimpleAdminHacks plugin,
+                          @NotNull final ElytraFeaturesConfig config) {
         super(plugin, config);
     }
 
-    public static ElytraFeaturesConfig generate(@Nonnull final SimpleAdminHacks plugin,
-                                                @Nonnull final ConfigurationSection config) {
+    public static ElytraFeaturesConfig generate(@NotNull final SimpleAdminHacks plugin,
+                                                @NotNull final ConfigurationSection config) {
         return new ElytraFeaturesConfig(plugin, config);
     }
 
@@ -67,7 +67,7 @@ public final class ElytraFeatures extends SimpleHack<ElytraFeaturesConfig> imple
     // ------------------------------------------------------------
 
     @EventHandler(ignoreCancelled = true)
-    public void regulateElytraFlight(@Nonnull final EntityToggleGlideEvent event) {
+    public void regulateElytraFlight(@NotNull final EntityToggleGlideEvent event) {
         boolean disableFlight = false;
         if (config().isFlightDisabled()) {
             disableFlight = true;
@@ -88,7 +88,7 @@ public final class ElytraFeatures extends SimpleHack<ElytraFeaturesConfig> imple
     // ------------------------------------------------------------
 
     @EventHandler(ignoreCancelled = true)
-    public void regulateElytraBoosting(@Nonnull final PlayerElytraBoostEvent event) {
+    public void regulateElytraBoosting(@NotNull final PlayerElytraBoostEvent event) {
         boolean disableBoosting = false;
         if (config().isBoostingDisabled()) {
             disableBoosting = true;

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -4,7 +4,6 @@ import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.configs.GameTuningConfig;
 import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.utilities.TeleportUtil;
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -52,6 +51,7 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.meta.SpawnEggMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 /**
@@ -467,7 +467,7 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
     }
 
     @Override
-    public boolean onCommand(@Nonnull CommandSender commandSender, @Nonnull Command command, @Nonnull String s, @Nonnull String[] strings) {
+    public boolean onCommand(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, @NotNull String[] strings) {
         Map<Material, Integer> blockLimits = config.getBlockEntityLimits();
 
         StringBuilder stringB = new StringBuilder();

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/BeeKeeping.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/BeeKeeping.java
@@ -35,11 +35,11 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.utilities.MoreCollectionUtils;
 
-import javax.annotation.Nonnull;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -187,7 +187,7 @@ public final class BeeKeeping extends BasicHack {
         player.sendMessage(response);
     }
 
-    private static BeehiveBlockEntity getBeeHive(@Nonnull final Block block) {
+    private static BeehiveBlockEntity getBeeHive(@NotNull final Block block) {
         final CraftBlock craftBlock = (CraftBlock) block;
         final CraftWorld craftWorld = craftBlock.getCraftWorld();
         final ServerLevel worldServer = craftWorld.getHandle();
@@ -195,7 +195,7 @@ public final class BeeKeeping extends BasicHack {
         return (BeehiveBlockEntity) Objects.requireNonNull(tileEntity);
     }
 
-    private static List<BeeData> getBeesFromHive(@Nonnull final BeehiveBlockEntity hive) {
+    private static List<BeeData> getBeesFromHive(@NotNull final BeehiveBlockEntity hive) {
         List<BeehiveBlockEntity.Occupant> bees = hive.components().get(DataComponents.BEES);
 
 		return bees == null ? null : bees.stream().map(bee -> bee.entityData().copyTag()).map(BeeData::new).collect(Collectors.toCollection(ArrayList::new));
@@ -205,7 +205,7 @@ public final class BeeKeeping extends BasicHack {
 
         public final Component name;
 
-        public BeeData(@Nonnull final CompoundTag nbt) {
+        public BeeData(@NotNull final CompoundTag nbt) {
             // Parse name
             final String rawName = nbt.getString(BEE_NAME_KEY);
             if (Strings.isNullOrEmpty(rawName)) {


### PR DESCRIPTION
Switches out the javax annotations in favour of Jetbrains Annotations, thus removing a shaded dependency in CivModCore.