### PR TITLE
Add contracts to some ItemUtils

### DIFF
--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemUtils.java
@@ -54,6 +54,7 @@ public final class ItemUtils {
      * @param item The item to check.
      * @return Returns true if the item can be interpreted as an empty slot.
      */
+    @Contract("null -> true")
     public static boolean isEmptyItem(final ItemStack item) {
         return item == null || item.getType() == Material.AIR;
     }
@@ -66,6 +67,7 @@ public final class ItemUtils {
      * @param item The item to validate.
      * @return Returns true if the item is valid.
      */
+    @Contract("null -> false")
     public static boolean isValidItem(@Nullable final ItemStack item) {
         return !isEmptyItem(item)
             && isValidItemMaterial(item.getType())
@@ -81,6 +83,7 @@ public final class ItemUtils {
      * @param item The item to validate.
      * @return Returns true if the item is valid.
      */
+    @Contract("null -> false")
     public static boolean isValidItemIgnoringAmount(@Nullable final ItemStack item) {
         return item != null
             && isValidItemMaterial(item.getType())
@@ -93,6 +96,7 @@ public final class ItemUtils {
      * @param item The item to validate.
      * @return Returns true if the item has a valid amount.
      */
+    @Contract("null -> false")
     public static boolean isValidItemAmount(@Nullable final ItemStack item) {
         return item != null
             && item.getAmount() > 0
@@ -105,6 +109,7 @@ public final class ItemUtils {
      * @param material The material to check.
      * @return Returns true if the material would be considered a valid item.
      */
+    @Contract("null -> false")
     public static boolean isValidItemMaterial(@Nullable final Material material) {
         return material != null
             /** Add any null-returns in {@link CraftItemFactory#getItemMeta(Material, org.bukkit.craftbukkit.inventory.CraftMetaItem)} */


### PR DESCRIPTION
Sometimes IDEs will fret if you use an item after doing an `if (ItemUtils.isEmptyItem(item)) return;` because it doesn't know that the method is also a null check. These contracts will placate the IDE, removing the warnings, resulting in less confusion and less bytecode.