### PR TITLE
Prune ChatUtils and related uses

### DIFF
--- a/plugins/bastion-paper/src/main/java/isaac/bastion/listeners/BastionDamageListener.java
+++ b/plugins/bastion-paper/src/main/java/isaac/bastion/listeners/BastionDamageListener.java
@@ -34,7 +34,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.event.world.StructureGrowEvent;
 import org.bukkit.inventory.ItemStack;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
@@ -65,7 +65,7 @@ public final class BastionDamageListener implements Listener {
                     blockManager.erodeFromPlace(event.getPlayer(), blocking);
                 } else {
                     event.getPlayer().sendMessage(String.format("%s%s cannot be used to damage bastions", ChatColor.RED,
-                        ItemUtils.getItemName(mat)));
+                        ChatUtils.translate(mat)));
                 }
                 return;
             }

--- a/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/listeners/KillListener.java
+++ b/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/listeners/KillListener.java
@@ -13,6 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.civchat2.database.CivChatDAO;
 import vg.civcraft.mc.civchat2.utility.CivChat2Config;
 import vg.civcraft.mc.civchat2.utility.CivChat2SettingsManager;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.MaterialUtils;
 
@@ -47,7 +48,7 @@ public class KillListener implements Listener {
             msg = String.format("%s%s %swas killed by %s %sby hand", ChatColor.DARK_GRAY, victimFormattedName,
                 ChatColor.DARK_GRAY, killerFormattedName, ChatColor.DARK_GRAY);
         } else {
-            String itemName = ItemUtils.getItemName(item);
+            String itemName = ChatUtils.translate(item);
             String displayName = ItemUtils.getDisplayName(item);
             Boolean hasWordBank = Optional.ofNullable(ItemUtils.getItemMeta(item))
                 .map(r -> r.displayName())

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/ChatUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/ChatUtils.java
@@ -1,98 +1,21 @@
 package vg.civcraft.mc.civmodcore.chat;
 
-import io.papermc.paper.adventure.PaperAdventure;
-import java.awt.Color;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.text.event.HoverEvent;
-import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import net.md_5.bungee.api.ChatColor;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.ArrayUtils;
+import net.kyori.adventure.translation.Translatable;
 import org.apache.commons.lang3.StringUtils;
-import org.bukkit.craftbukkit.util.CraftChatMessage;
-import org.bukkit.inventory.ItemStack;
+import org.bukkit.ChatColor;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 public final class ChatUtils {
-
-    /**
-     * This is necessary as {@link ChatColor#values()} has all colours <i>and</i> all formats.
-     *
-     * @deprecated Use {@link NamedTextColor} instead.
-     */
-    @Deprecated
-    public static final List<ChatColor> COLOURS = List.of(
-        ChatColor.BLACK,
-        ChatColor.DARK_BLUE,
-        ChatColor.DARK_GREEN,
-        ChatColor.DARK_AQUA,
-        ChatColor.DARK_RED,
-        ChatColor.DARK_PURPLE,
-        ChatColor.GOLD,
-        ChatColor.GRAY,
-        ChatColor.DARK_GRAY,
-        ChatColor.BLUE,
-        ChatColor.GREEN,
-        ChatColor.AQUA,
-        ChatColor.RED,
-        ChatColor.LIGHT_PURPLE,
-        ChatColor.YELLOW);
-
-    /**
-     * Converts an RGB value into a Bungee ChatColor.
-     *
-     * @param r The red value.
-     * @param g The green value.
-     * @param b The blue value.
-     * @return Returns a valid Bungee ChatColor.
-     * @deprecated Use {@link net.kyori.adventure.text.format.TextColor#color(int, int, int)} instead.
-     */
-    @NotNull
-    @Deprecated
-    public static ChatColor fromRGB(final byte r, final byte g, final byte b) {
-        return ChatColor.of(new Color(r, g, b));
-    }
-
-    /**
-     * Attempts to collapse an RGB colour to established Minecraft colours.
-     *
-     * @param colour The given RGB colour.
-     * @return Returns the closest Minecraft match, or null.
-     */
-    @Contract("!null -> !null")
-    @Nullable
-    public static ChatColor collapseColour(@Nullable final ChatColor colour) {
-        if (colour == null) {
-            return null;
-        }
-        final Color color = colour.getColor();
-        ChatColor nearestColour = null;
-        double nearestDistance = Double.MAX_VALUE;
-        for (final ChatColor currentColour : COLOURS) {
-            final Color currentColor = currentColour.getColor();
-            final double distance = Math.sqrt(
-                Math.pow(color.getRed() - currentColor.getRed(), 2)
-                    - Math.pow(color.getGreen() - currentColor.getGreen(), 2)
-                    - Math.pow(color.getBlue() - currentColor.getBlue(), 2));
-            if (nearestDistance > distance) {
-                nearestDistance = distance;
-                nearestColour = currentColour;
-            }
-        }
-        return nearestColour;
-    }
-
     // -------------------------------------------- //
     // Color parsing
     // -------------------------------------------- //
@@ -101,9 +24,10 @@ public final class ChatUtils {
      * @deprecated Please use MiniMessage instead.
      * <a href="https://docs.adventure.kyori.net/minimessage.html">Read More</a>.
      */
-    @NotNull
     @Deprecated
-    public static String parseColor(@NotNull String string) {
+    public static @NotNull String parseColor(
+        @NotNull String string
+    ) {
         string = parseColorAmp(string);
         string = parseColorAcc(string);
         string = parseColorTags(string);
@@ -114,9 +38,10 @@ public final class ChatUtils {
      * @deprecated Please use MiniMessage instead.
      * <a href="https://docs.adventure.kyori.net/minimessage.html">Read More</a>.
      */
-    @NotNull
     @Deprecated
-    public static String parseColorAmp(@NotNull String string) {
+    public static @NotNull String parseColorAmp(
+        @NotNull String string
+    ) {
         string = string.replace("&&", "&");
         return ChatColor.translateAlternateColorCodes('&', string);
     }
@@ -125,9 +50,10 @@ public final class ChatUtils {
      * @deprecated Please use MiniMessage instead.
      * <a href="https://docs.adventure.kyori.net/minimessage.html">Read More</a>.
      */
-    @NotNull
     @Deprecated
-    public static String parseColorAcc(@NotNull String string) {
+    public static @NotNull String parseColorAcc(
+        final @NotNull String string
+    ) {
         return ChatColor.translateAlternateColorCodes('`', string);
     }
 
@@ -135,9 +61,10 @@ public final class ChatUtils {
      * @deprecated Please use MiniMessage instead.
      * <a href="https://docs.adventure.kyori.net/minimessage.html">Read More</a>.
      */
-    @NotNull
     @Deprecated
-    public static String parseColorTags(@NotNull String string) {
+    public static @NotNull String parseColorTags(
+        final @NotNull String string
+    ) {
         return string
             .replace("<black>", ChatColor.BLACK.toString())
             .replace("<dblue>", ChatColor.DARK_BLUE.toString())
@@ -198,155 +125,53 @@ public final class ChatUtils {
      *
      * @param component The component to test if null or empty.
      * @return Returns true if the component is null or has no visible content.
-     * @deprecated Has been deprecated due to Paper's move to Kyori's Adventure.
      */
-    public static boolean isNullOrEmpty(@Nullable final Component component) {
+    @Contract("null -> true")
+    public static boolean isNullOrEmpty(
+        final Component component
+    ) {
         if (component == null || component == Component.empty()) {
             return true;
         }
-        return StringUtils.isBlank(PlainTextComponentSerializer.plainText().serialize(component));
+        return StringUtils.isEmpty(PlainTextComponentSerializer.plainText().serialize(component));
     }
 
     /**
-     * <p>Determines whether a given base component is null or empty.</p>
-     *
-     * <p>This is determined by converting the component into plain text, so a non-null component filled with
-     * nothing but colour codes and hover text will likely return true.</p>
-     *
-     * @param component The component to test if null or empty.
-     * @return Returns true if the component is null or has no visible content.
+     * Determines whether a given component is a base component, ie, a
+     * component that has no style or content of its own, whose only job is
+     * to contain other components.
      */
-    public static boolean isBaseComponent(@Nullable final Component component) {
-        if (component == null) {
-            return false;
-        }
-        return (!(component instanceof TextComponent textComponent) || StringUtils.isEmpty(textComponent.content()))
-            && !component.children().isEmpty()
-            && component.clickEvent() == null
-            && component.hoverEvent() == null
-            && !component.hasStyling();
+    @Contract("null -> false")
+    public static boolean isBaseComponent(
+        final Component component
+    ) {
+        return component instanceof final TextComponent textComponent
+            && StringUtils.isEmpty(textComponent.content())
+            && !component.hasStyling()
+            && !component.children().isEmpty();
     }
 
-    private static final Map<TextDecoration, TextDecoration.State> NORMALISED_DECORATION_MAP =
-        Map.of(TextDecoration.ITALIC, TextDecoration.State.FALSE);
-
-    /**
-     * Checks whether a given component is the result of {@link #normaliseComponent(Component...)} or
-     * {@link #normaliseComponent(List)}.
-     *
-     * @param component The component to check.
-     * @return Returns true if the given component is "normalised."
-     */
-    public static boolean isNormalisedComponent(@Nullable final Component component) {
-        if (!(component instanceof final TextComponent textComponent)) {
-            return false;
-        }
-        return StringUtils.isEmpty(textComponent.content())
-            && !component.children().isEmpty()
-            && component.clickEvent() == null
-            && component.hoverEvent() == null
-            && Objects.equals(component.color(), NamedTextColor.WHITE)
-            && Objects.equals(component.decorations(), NORMALISED_DECORATION_MAP);
-    }
-
-    /**
-     * Wraps a component or series of components into a "normalised" display component, meaning that the text is
-     * white and non-italic by default.
-     *
-     * @param components The component / components to wrap.
-     * @return Returns the normalised component, or empty if no components are passed.
-     */
-    @NotNull
-    public static Component normaliseComponent(final Component... components) {
-        if (ArrayUtils.isEmpty(components)) {
-            return Component.empty();
-        }
-        return Component.text()
-            .color(NamedTextColor.WHITE)
-            .decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE)
-            .append(components)
-            .build();
-    }
-
-    /**
-     * Wraps a series of components into a "normalised" display component, meaning that the text is white and
-     * non-italic by default.
-     *
-     * @param components The components to wrap.
-     * @return Returns the normalised component, or empty if no components are passed.
-     */
-    @NotNull
-    public static Component normaliseComponent(@Nullable final List<Component> components) {
-        if (CollectionUtils.isEmpty(components)) {
-            return Component.empty();
-        }
-        return Component.text()
-            .color(NamedTextColor.WHITE)
-            .decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE)
-            .append(components)
-            .build();
-    }
-
-    /**
-     * This will also happily translate any translatable components.
-     *
-     * @param component The component to stringify.
-     * @return Returns a stringified version of the given component.
-     */
-    @NotNull
-    public static String stringify(@Nullable final Component component) {
-        return component == null || component == Component.empty() ? "" :
-            CraftChatMessage.fromComponent(PaperAdventure.asVanilla(component));
-    }
-
-    /**
-     * Upgrades a legacy string (eg: §6Hello, World!) to a Kyori component.
-     *
-     * @param string The string to convert into a component.
-     * @return Returns a new component, or null if the given string was null.
-     */
     @Contract("!null -> !null")
-    @Nullable
-    public static Component upgradeLegacyString(@Nullable final String string) {
-        return string == null ? null : string.isEmpty() ? Component.empty() :
-            LegacyComponentSerializer.legacySection().deserialize(string);
+    public static @Nullable String translate(
+        final Translatable translatable
+    ) {
+        return translatable == null ? null : translate(Component.translatable(translatable));
+    }
+
+    @Contract("!null -> !null")
+    public static @Nullable String translate(
+        final TranslatableComponent component
+    ) {
+        return component == null ? null : PlainTextComponentSerializer.plainText().serialize(component);
     }
 
     /**
-     * @return Generates a new text component that's specifically <i>NOT</i> italicised. Use this for item names and
-     * lore.
+     * Creates a new component builder that is explicitly non-italic, good for
+     * item display components like display names and lore.
      */
-    @NotNull
-    public static TextComponent newComponent() {
-        return newComponent("");
-    }
-
-    /**
-     * Generates a new text component that's specifically <i>NOT</i> italicised. Use this for item names and lore.
-     *
-     * @param content The text content for the component.
-     * @return Returns the generated text component.
-     */
-    @NotNull
-    public static TextComponent newComponent(final String content) {
-        return Component.text(Objects.requireNonNull(content))
+    public static @NotNull TextComponent.Builder nonItalic() {
+        return Component.text()
             .decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE);
-    }
-
-    /**
-     * Clones a component.
-     *
-     * @param component The component to clone.
-     * @return Returns a clone of the given component.
-     * @deprecated Kyori components are immutable, so any methods that offer to update the component will actually
-     * instantiate a new component with the modification, thus making this utility unnecessary, if not
-     * downright inefficient.
-     */
-    @Contract("!null -> !null")
-    @Nullable
-    @Deprecated(forRemoval = true)
-    public static Component cloneComponent(@Nullable final Component component) {
-        return component == null ? null : component.style(component.style());
     }
 
     /**
@@ -356,8 +181,11 @@ public final class ChatUtils {
      * @param latter The right hand side component.
      * @return Returns whether the two given components are equal.
      */
-    public static boolean areComponentsEqual(@Nullable final Component former,
-                                             @Nullable final Component latter) {
+    @Contract("null, null -> true; null, !null -> false; !null, null -> false")
+    public static boolean areComponentsEqual(
+        final Component former,
+        final Component latter
+    ) {
         if (Objects.equals(former, latter)) {
             return true;
         }
@@ -375,27 +203,5 @@ public final class ChatUtils {
             return true;
         }
         return false;
-    }
-
-    /**
-     * Converts a given item into a hover event.
-     *
-     * @param item The item to convert.
-     * @return Returns a valid hover event of the item, or if the item is null, a representation of that.
-     */
-    @NotNull
-    public static HoverEvent<?> createItemHoverEvent(@org.jetbrains.annotations.Nullable final ItemStack item) {
-        if (ItemUtils.isEmptyItem(item)) {
-            return HoverEvent.showText(Component.text()
-                .color(NamedTextColor.RED)
-                .content("<null item>")
-                .build());
-        }
-        return HoverEvent.showItem(
-            item.getType().getKey(),
-            item.getAmount()
-            // TODO: There's a variant of this method that includes an NBT compound. My guess is to include display
-            //       name and lore, perhaps also enchantments, etc..
-        );
     }
 }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/Componentify.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/Componentify.java
@@ -1,67 +1,82 @@
 package vg.civcraft.mc.civmodcore.chat;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public final class Componentify {
-
-    private static Component INTERNAL_addLocationWorld(@Nullable final Location location) {
-        if (location.isWorldLoaded()) {
-            return Component.text(location.getWorld().getName())
-                .hoverEvent(HoverEvent.showText(Component.text("World name")));
-        } else {
-            return Component.text("<null>")
+    private static @NotNull Component INTERNAL_addLocationWorld(
+        final Location location
+    ) {
+        if (location == null || !location.isWorldLoaded()) {
+            return Component.text()
                 .color(NamedTextColor.RED)
-                .hoverEvent(HoverEvent.showText(Component.text("World not specified / loaded")));
+                .content("<null>")
+                .hoverEvent(HoverEvent.showText(Component.text("World not specified / loaded")))
+                .build();
         }
+        return Component.text()
+            .content(location.getWorld().getName())
+            .hoverEvent(HoverEvent.showText(Component.text("World name")))
+            .build();
     }
 
-    public static Component fullLocation(@NotNull final Location location) {
-        final var component = Component.text();
-        component.append(INTERNAL_addLocationWorld(location));
-        component.append(Component.space());
-        component.append(Component.text(location.getX())
-            .color(NamedTextColor.RED)
-            .hoverEvent(HoverEvent.showText(Component.text("X"))));
-        component.append(Component.space());
-        component.append(Component.text(location.getY())
-            .color(NamedTextColor.GREEN)
-            .hoverEvent(HoverEvent.showText(Component.text("Y"))));
-        component.append(Component.space());
-        component.append(Component.text(location.getZ())
-            .color(NamedTextColor.BLUE)
-            .hoverEvent(HoverEvent.showText(Component.text("Z"))));
-        component.append(Component.space());
-        component.append(Component.text(location.getYaw())
-            .color(NamedTextColor.GOLD)
-            .hoverEvent(HoverEvent.showText(Component.text("Yaw"))));
-        component.append(Component.space());
-        component.append(Component.text(location.getPitch())
-            .color(NamedTextColor.AQUA)
-            .hoverEvent(HoverEvent.showText(Component.text("Pitch"))));
-        return component.build();
+    public static @NotNull ComponentLike @NotNull [] fullLocation(
+        final @NotNull Location location
+    ) {
+        return new ComponentLike[] {
+            INTERNAL_addLocationWorld(location),
+            Component.space(),
+            Component.text()
+                .color(NamedTextColor.RED)
+                .content(String.valueOf(location.getX()))
+                .hoverEvent(HoverEvent.showText(Component.text("X"))),
+            Component.space(),
+            Component.text()
+                .color(NamedTextColor.GREEN)
+                .content(String.valueOf(location.getY()))
+                .hoverEvent(HoverEvent.showText(Component.text("Y"))),
+            Component.space(),
+            Component.text()
+                .color(NamedTextColor.BLUE)
+                .content(String.valueOf(location.getZ()))
+                .hoverEvent(HoverEvent.showText(Component.text("Z"))),
+            Component.space(),
+            Component.text()
+                .color(NamedTextColor.GOLD)
+                .content(String.valueOf(location.getYaw()))
+                .hoverEvent(HoverEvent.showText(Component.text("Yaw"))),
+            Component.space(),
+            Component.text()
+                .color(NamedTextColor.AQUA)
+                .content(String.valueOf(location.getPitch()))
+                .hoverEvent(HoverEvent.showText(Component.text("Pitch")))
+        };
     }
 
-    public static Component blockLocation(@NotNull final Location location) {
-        final var component = Component.text();
-        component.append(INTERNAL_addLocationWorld(location));
-        component.append(Component.space());
-        component.append(Component.text(location.getBlockX())
-            .color(NamedTextColor.RED)
-            .hoverEvent(HoverEvent.showText(Component.text("Block X"))));
-        component.append(Component.space());
-        component.append(Component.text(location.getBlockY())
-            .color(NamedTextColor.GREEN)
-            .hoverEvent(HoverEvent.showText(Component.text("Block X"))));
-        component.append(Component.space());
-        component.append(Component.text(location.getBlockZ())
-            .color(NamedTextColor.BLUE)
-            .hoverEvent(HoverEvent.showText(Component.text("Block X"))));
-        return component.build();
+    public static @NotNull ComponentLike @NotNull [] blockLocation(
+        final @NotNull Location location
+    ) {
+        return new ComponentLike[] {
+            INTERNAL_addLocationWorld(location),
+            Component.space(),
+            Component.text()
+                .color(NamedTextColor.RED)
+                .content(String.valueOf(location.getBlockX()))
+                .hoverEvent(HoverEvent.showText(Component.text("Block X"))),
+            Component.space(),
+            Component.text()
+                .color(NamedTextColor.GREEN)
+                .content(String.valueOf(location.getBlockY()))
+                .hoverEvent(HoverEvent.showText(Component.text("Block Y"))),
+            Component.space(),
+            Component.text()
+                .color(NamedTextColor.BLUE)
+                .content(String.valueOf(location.getBlockZ()))
+                .hoverEvent(HoverEvent.showText(Component.text("Block Z")))
+        };
     }
-
 }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/EnchantUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/EnchantUtils.java
@@ -10,8 +10,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.translation.Translatable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.enchantments.Enchantment;
@@ -20,7 +18,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.CivModCorePlugin;
-import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 
@@ -100,17 +97,6 @@ public final class EnchantUtils {
             return enchantment;
         }
         return null;
-    }
-
-    /**
-     * @param enchant The enchantment to get the name of.
-     * @return Returns the name of the enchantment, or null.
-     * @deprecated Use {@link Component#translatable(Translatable)} instead.
-     */
-    @Nullable
-    @Deprecated
-    public static String getEnchantNiceName(@Nullable final Enchantment enchant) {
-        return enchant == null ? null : ChatUtils.stringify(Component.translatable(enchant));
     }
 
     /**

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/ItemUtils.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.translation.Translatable;
 import org.bukkit.Material;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.inventory.ItemStack;
@@ -15,39 +14,11 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 
 /**
  * Class of static APIs for Items. Replaces ISUtils.
  */
 public final class ItemUtils {
-
-    /**
-     * Gets the name of an item based off a material, e.g: POLISHED_GRANITE to Polished Granite
-     *
-     * @param material The material to get the name of.
-     * @return Returns the material name.
-     * @deprecated Use {@link Component#translatable(Translatable)} instead.
-     */
-    @Deprecated
-    @NotNull
-    public static String getItemName(@NotNull final Material material) {
-        return ChatUtils.stringify(Component.translatable(Objects.requireNonNull(material)));
-    }
-
-    /**
-     * Gets the name of an item either based off its material or its custom item tag.
-     *
-     * @param item The item to get the name of.
-     * @return Returns the item's name.
-     * @deprecated Use {@link Component#translatable(Translatable)} instead.
-     */
-    @Deprecated
-    @Nullable
-    public static String getItemName(@Nullable final ItemStack item) {
-        return item == null ? null : ChatUtils.stringify(Component.translatable(item));
-    }
-
     /**
      * Checks whether the given item can be interpreted as an empty slot.
      *

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/PotionUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/PotionUtils.java
@@ -4,20 +4,15 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectAVLTreeMap;
 import java.util.Map;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
-import net.kyori.adventure.translation.Translatable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
-import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 
 public final class PotionUtils {
-
     private static final Map<Pair<Material, PotionType>, TranslatableComponent> POTION_TRANSLATIONS = new Object2ObjectAVLTreeMap<>();
 
     /**
@@ -48,28 +43,5 @@ public final class PotionUtils {
             });
             return Component.translatable(item.translationKey());
         });
-    }
-
-    /**
-     * @param potion The potion type to get the name of.
-     * @return Returns the name of the potion, or null.
-     * @deprecated Use {@link #asTranslatable(PotionType)} or
-     * {@link #asTranslatable(Material, PotionType)} instead.
-     */
-    @Deprecated
-    @Nullable
-    public static String getPotionNiceName(@Nullable final PotionType potion) {
-        return potion == null ? null : ChatUtils.stringify(asTranslatable(potion));
-    }
-
-    /**
-     * @param effect The potion effect to get the name of.
-     * @return Returns the name of the potion effect, or null.
-     * @deprecated Use {@link Component#translatable(Translatable)} instead.
-     */
-    @Deprecated
-    @Nullable
-    public static String getEffectNiceName(@Nullable final PotionEffectType effect) {
-        return effect == null ? null : ChatUtils.stringify(Component.translatable(effect));
     }
 }

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/command/CmdShowAllPearls.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/command/CmdShowAllPearls.java
@@ -20,7 +20,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextDecoration;
 import net.md_5.bungee.api.ChatColor;
 import org.apache.commons.collections4.ComparatorUtils;
 import org.apache.commons.collections4.list.LazyList;
@@ -112,56 +111,72 @@ public class CmdShowAllPearls extends PearlCommand {
                 Consumer<ItemStack> itemMetaMod = itemToMod ->
                     ItemUtils.handleItemMeta(itemToMod, (ItemMeta meta) -> {
                         // Pearled player's name
-                        meta.displayName(ChatUtils.newComponent(pearl.getPlayerName())
-                            .color(NamedTextColor.AQUA)
-                            .append(isPlayerBanned ?
-                                Component.text(" <banned>")
-                                    .color(NamedTextColor.RED) :
-                                Component.empty()));
+                        meta.displayName(
+                            ChatUtils.nonItalic()
+                                .color(NamedTextColor.AQUA)
+                                .content(pearl.getPlayerName())
+                                .append(
+                                    isPlayerBanned
+                                        ? Component.text(" <banned>", NamedTextColor.RED)
+                                        : Component.empty()
+                                )
+                                .build()
+                        );
 
                         meta.lore(List.of(
                             // Pearl type
-                            ChatUtils.newComponent(pearl.getItemName())
-                                .color(NamedTextColor.GREEN),
+                            ChatUtils.nonItalic()
+                                .color(NamedTextColor.GREEN)
+                                .content(pearl.getItemName())
+                                .build(),
                             // Pearled player's name and hash
-                            ChatUtils.newComponent("Player: ")
+                            ChatUtils.nonItalic()
                                 .color(NamedTextColor.GOLD)
-                                .append(Component.text(pearl.getPlayerName())
-                                    .color(NamedTextColor.GRAY))
-                                .append(Component.space())
-                                .append(Component.text(Integer.toString(pearl.getPearlId(), 36).toUpperCase())
-                                    .color(NamedTextColor.DARK_GRAY)),
+                                .content("Player: ")
+                                .append(
+                                    Component.text(pearl.getPlayerName(), NamedTextColor.GRAY),
+                                    Component.space(),
+                                    Component.text(Integer.toString(pearl.getPearlId(), 36).toUpperCase(), NamedTextColor.DARK_GRAY)
+                                )
+                                .build(),
                             // Pearled Date
-                            ChatUtils.newComponent("Pearled: ")
+                            ChatUtils.nonItalic()
                                 .color(NamedTextColor.GOLD)
-                                .append(Component.text(DATE_FORMAT.format(pearl.getPearledOn()))
-                                    .color(NamedTextColor.GRAY)),
+                                .content("Pearled: ")
+                                .append(Component.text(DATE_FORMAT.format(pearl.getPearledOn()), NamedTextColor.GRAY))
+                                .build(),
                             // Killer's name
-                            ChatUtils.newComponent("Killed by: ")
+                            ChatUtils.nonItalic()
                                 .color(NamedTextColor.GOLD)
-                                .append(Component.text(pearl.getKillerName())
-                                    .color(NamedTextColor.GRAY))));
+                                .content("Killed by: ")
+                                .append(Component.text(pearl.getKillerName(), NamedTextColor.GRAY))
+                                .build()
+                        ));
 
                         if (showLocation) {
-                            MetaUtils.addComponentLore(meta,
+                            MetaUtils.addComponentLore(
+                                meta,
                                 // Pearl location
-                                ChatUtils.newComponent("Location: ")
+                                ChatUtils.nonItalic()
                                     .color(NamedTextColor.GOLD)
-                                    .append(Component.text(pearlLocation.getWorld().getName())
-                                        .color(NamedTextColor.WHITE))
-                                    .append(Component.space())
-                                    .append(Component.text(pearlLocation.getBlockX())
-                                        .color(NamedTextColor.RED))
-                                    .append(Component.space())
-                                    .append(Component.text(pearlLocation.getBlockY())
-                                        .color(NamedTextColor.GREEN))
-                                    .append(Component.space())
-                                    .append(Component.text(pearlLocation.getBlockZ())
-                                        .color(NamedTextColor.BLUE)),
+                                    .content("Location: ")
+                                    .append(
+                                        Component.text(pearlLocation.getWorld().getName(), NamedTextColor.WHITE),
+                                        Component.space(),
+                                        Component.text(pearlLocation.getBlockX(), NamedTextColor.RED),
+                                        Component.space(),
+                                        Component.text(pearlLocation.getBlockY(), NamedTextColor.GREEN),
+                                        Component.space(),
+                                        Component.text(pearlLocation.getBlockZ(), NamedTextColor.BLUE)
+                                    )
+                                    .build(),
                                 // Waypoint
                                 Component.space(),
-                                ChatUtils.newComponent("Click to receive a waypoint")
-                                    .color(NamedTextColor.GREEN));
+                                ChatUtils.nonItalic()
+                                    .color(NamedTextColor.GREEN)
+                                    .content("Click to receive a waypoint")
+                                    .build()
+                            );
                         }
                         return true;
                     });
@@ -201,9 +216,13 @@ public class CmdShowAllPearls extends PearlCommand {
 
         if (contentSuppliers.isEmpty()) {
             final var item = new ItemStack(Material.BARRIER);
-            ItemUtils.setComponentDisplayName(item,
-                ChatUtils.newComponent("There are currently no pearls.")
-                    .color(NamedTextColor.RED));
+            ItemUtils.setComponentDisplayName(
+                item,
+                ChatUtils.nonItalic()
+                    .color(NamedTextColor.RED)
+                    .content("There are currently no pearls.")
+                    .build()
+            );
             contentSuppliers.add(() -> new DecorationStack(item));
         }
 
@@ -217,17 +236,18 @@ public class CmdShowAllPearls extends PearlCommand {
     private IClickable constructBannedPearlsToggleClick(final boolean bannedPearlToggle) {
         final var item = new ItemStack(Material.BARRIER);
         ItemUtils.handleItemMeta(item, (final ItemMeta meta) -> {
-            meta.displayName(Component.text()
-                .decoration(TextDecoration.ITALIC, false)
-                .color(NamedTextColor.GOLD)
-                .content("Toggle banned pearls")
-                .build());
-            MetaUtils.setComponentLore(meta,
-                Component.text()
-                    .decoration(TextDecoration.ITALIC, false)
+            meta.displayName(
+                ChatUtils.nonItalic()
+                    .color(NamedTextColor.GOLD)
+                    .content("Toggle banned pearls")
+                    .build()
+            );
+            meta.lore(List.of(
+                ChatUtils.nonItalic()
                     .color(NamedTextColor.AQUA)
                     .content("Currently turned " + (bannedPearlToggle ? "on" : "off"))
-                    .build());
+                    .build()
+            ));
             return true;
         });
         return new Clickable(item) {

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/holder/BlockHolder.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/holder/BlockHolder.java
@@ -15,7 +15,7 @@ import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.world.WorldUtils;
 
 /**
@@ -47,7 +47,7 @@ public class BlockHolder implements PearlHolder {
                 customNameString = String.format(" %scalled %s", ChatColor.RESET, customName);
             }
         }
-        return String.format("a %s%s", ItemUtils.getItemName(block.getType()), customNameString);
+        return String.format("a %s%s", ChatUtils.translate(block.getType()), customNameString);
     }
 
     @Override

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
@@ -42,7 +42,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.citadel.ReinforcementLogic;
 import vg.civcraft.mc.citadel.model.Reinforcement;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
@@ -325,7 +325,7 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
             if (p != null) {
                 ItemStack fuel = ((FurnacePowerManager) pm).getFuel().clone();
                 if (fuel != null) {
-                    p.sendMessage(ChatColor.RED + "Failed to activate factory, there is no fuel (" + ItemUtils.getItemName(fuel) + ") in the furnace");
+                    p.sendMessage(ChatColor.RED + "Failed to activate factory, there is no fuel (" + ChatUtils.translate(fuel) + ") in the furnace");
                 } else {
                     p.sendMessage(ChatColor.RED + "Failed to activate factory, there is no fuel in the furnace");
                 }

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/interactionManager/SorterInteractionManager.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/interactionManager/SorterInteractionManager.java
@@ -13,7 +13,7 @@ import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.citadel.ReinforcementLogic;
 import vg.civcraft.mc.citadel.model.Reinforcement;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 
 public class SorterInteractionManager implements IInteractionManager {
 
@@ -74,11 +74,11 @@ public class SorterInteractionManager implements IInteractionManager {
             BlockFace side = sorter.getSide(is);
             if (side == null) {
                 sorter.addAssignment(bf, is);
-                p.sendMessage(ChatColor.GREEN + "Added " + ItemUtils.getItemName(is) + " to " + bf.toString());
+                p.sendMessage(ChatColor.GREEN + "Added " + ChatUtils.translate(is) + " to " + bf.toString());
             } else {
                 if (side == bf) {
                     sorter.removeAssignment(is);
-                    p.sendMessage(ChatColor.GOLD + "Removed " + ItemUtils.getItemName(is) + " from " + side.toString());
+                    p.sendMessage(ChatColor.GOLD + "Removed " + ChatUtils.translate(is) + " from " + side.toString());
                 } else {
                     p.sendMessage(ChatColor.RED + "This item is already associated with " + side.toString());
                 }

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/DeterministicEnchantingRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/DeterministicEnchantingRecipe.java
@@ -12,6 +12,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
@@ -123,13 +124,13 @@ public class DeterministicEnchantingRecipe extends InputRecipe {
     @Override
     public List<String> getTextualInputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
         List<String> res = super.getTextualInputRepresentation(i, fccf);
-        res.add("1 " + ItemUtils.getItemName(tool.getItemStackRepresentation().get(0)));
+        res.add("1 " + ChatUtils.translate(tool.getItemStackRepresentation().get(0)));
         return res;
     }
 
     @Override
     public List<String> getTextualOutputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
-        return Arrays.asList("1 " + ItemUtils.getItemName(tool.getItemStackRepresentation().get(0)) + " with "
+        return Arrays.asList("1 " + ChatUtils.translate(tool.getItemStackRepresentation().get(0)) + " with "
             + enchant.toString() + " " + level);
     }
 }

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/InputRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/InputRecipe.java
@@ -14,6 +14,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.utilities.TextUtil;
@@ -216,9 +217,9 @@ public abstract class InputRecipe implements IRecipe {
         for (Entry<ItemStack, Integer> entry : ingredients.getEntrySet()) {
             if (entry.getValue() > 0) {
                 if (!entry.getKey().hasItemMeta()) {
-                    result.add(entry.getValue() + " " + ItemUtils.getItemName(entry.getKey()));
+                    result.add(entry.getValue() + " " + ChatUtils.translate(entry.getKey()));
                 } else {
-                    String lore = String.format("%s %s%s", entry.getValue(), ChatColor.ITALIC, ItemUtils.getItemName(entry.getKey()));
+                    String lore = String.format("%s %s%s", entry.getValue(), ChatColor.ITALIC, ChatUtils.translate(entry.getKey()));
                     if (entry.getKey().getItemMeta().hasDisplayName()) {
                         lore += String.format("%s [%s]", ChatColor.DARK_AQUA, StringUtils.abbreviate(entry.getKey().getItemMeta().getDisplayName(), 20));
                     }

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/LoreEnchantRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/LoreEnchantRecipe.java
@@ -12,6 +12,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
@@ -162,11 +163,11 @@ public class LoreEnchantRecipe extends InputRecipe {
 
     @Override
     public List<String> getTextualInputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
-        return Arrays.asList("1 " + ItemUtils.getItemName(exampleInput));
+        return Arrays.asList("1 " + ChatUtils.translate(exampleInput));
     }
 
     @Override
     public List<String> getTextualOutputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
-        return Arrays.asList("1 " + ItemUtils.getItemName(exampleOutput));
+        return Arrays.asList("1 " + ChatUtils.translate(exampleOutput));
     }
 }

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PylonRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PylonRecipe.java
@@ -12,6 +12,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
@@ -144,7 +145,7 @@ public class PylonRecipe extends InputRecipe {
         List<String> result = new ArrayList<>();
         for (Entry<ItemStack, Integer> entry : output.getEntrySet()) {
             if (entry.getValue() > 0) {
-                result.add(entry.getValue() + " " + ItemUtils.getItemName(entry.getKey()));
+                result.add(entry.getValue() + " " + ChatUtils.translate(entry.getKey()));
             }
         }
         return result;

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/RandomEnchantingRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/RandomEnchantingRecipe.java
@@ -12,7 +12,7 @@ import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import vg.civcraft.mc.civmodcore.inventory.items.EnchantUtils;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
@@ -84,7 +84,7 @@ public class RandomEnchantingRecipe extends InputRecipe {
         for (RandomEnchant re : enchants) {
             ItemUtils.addLore(is,
                 ChatColor.YELLOW + String.valueOf(re.chance * 100)
-                    + " % chance for " + EnchantUtils.getEnchantNiceName(re.enchant)
+                    + " % chance for " + ChatUtils.translate(re.enchant)
                     + " " + re.level);
         }
         ItemUtils.addLore(is, ChatColor.LIGHT_PURPLE

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/WordBankRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/WordBankRecipe.java
@@ -9,6 +9,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
@@ -74,7 +75,7 @@ public class WordBankRecipe extends InputRecipe {
         for (Entry<ItemStack, Integer> entry : input.getEntrySet()) {
             sb.append(entry.getValue());
             sb.append(" ");
-            sb.append(ItemUtils.getItemName(entry.getKey()));
+            sb.append(ChatUtils.translate(entry.getKey()));
             sb.append(", ");
         }
         String result = sb.substring(0, sb.length() - 2);

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/FactoryModGUI.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/FactoryModGUI.java
@@ -18,6 +18,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.gui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventory.gui.IClickable;
 import vg.civcraft.mc.civmodcore.inventory.gui.LClickable;
@@ -98,7 +99,7 @@ public class FactoryModGUI {
             ItemStack is = new ItemStack(firstRec.getRecipeRepresentationMaterial());
             ItemUtils.setDisplayName(is, ChatColor.DARK_GREEN + fccEgg.getName());
             List<String> lore = new ArrayList<>();
-            lore.add(ChatColor.DARK_AQUA + "Fuel: " + ChatColor.GRAY + ItemUtils.getItemName(fccEgg.getFuel().getType()));
+            lore.add(ChatColor.DARK_AQUA + "Fuel: " + ChatColor.GRAY + ChatUtils.translate(fccEgg.getFuel().getType()));
             lore.add("");
             lore.add(ChatColor.GOLD + String.valueOf(fccEgg.getRecipes().size() + " recipes:"));
             for (IRecipe rec : fccEgg.getRecipes()) {
@@ -148,7 +149,7 @@ public class FactoryModGUI {
             lore.add(ChatColor.GOLD + "Required materials:");
             for (Entry<ItemStack, Integer> entry : factory.getSetupCost().getEntrySet()) {
                 lore.add(ChatColor.GRAY + " - " + ChatColor.AQUA + entry.getValue() + " "
-                    + ItemUtils.getItemName(entry.getKey()));
+                    + ChatUtils.translate(entry.getKey()));
             }
             ItemUtils.addLore(is, lore);
         } else {
@@ -161,7 +162,7 @@ public class FactoryModGUI {
                     lore.add(ChatColor.GOLD + "Required materials for the upgrade:");
                     for (Entry<ItemStack, Integer> entry : upRec.getInput().getEntrySet()) {
                         lore.add(ChatColor.GRAY + " - " + ChatColor.AQUA + entry.getValue() + " "
-                            + ItemUtils.getItemName(entry.getKey()));
+                            + ChatUtils.translate(entry.getKey()));
                     }
                     ItemUtils.addLore(is, lore);
                     return new LClickable(is, p -> showRecipeFor(factory, upRec, true));
@@ -180,7 +181,7 @@ public class FactoryModGUI {
         }
         ItemStack is = factory.getFuel().clone();
         ItemUtils.setDisplayName(is, ChatColor.GOLD + "Fuel cost for recipe");
-        ItemUtils.addLore(is, ChatColor.AQUA + "- " + recipe.getTotalFuelConsumed() + " " + ItemUtils.getItemName(is.getType()));
+        ItemUtils.addLore(is, ChatColor.AQUA + "- " + recipe.getTotalFuelConsumed() + " " + ChatUtils.translate(is.getType()));
         return new DecorationStack(is);
     }
 

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/ItemUseGUI.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/ItemUseGUI.java
@@ -14,6 +14,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.gui.IClickable;
 import vg.civcraft.mc.civmodcore.inventory.gui.LClickable;
 import vg.civcraft.mc.civmodcore.inventory.gui.components.ComponableInventory;
@@ -82,14 +83,14 @@ public class ItemUseGUI {
         if (itemAsInput.isEmpty()) {
             ItemStack noItems = new ItemStack(Material.BARRIER);
             ItemUtils.setDisplayName(noItems, String.format("%sNo recipes take input %s%s", ChatColor.RED, ChatColor.BOLD,
-                ItemUtils.getItemName(item)));
+                ChatUtils.translate(item)));
             itemAsInput.add(new LClickable(noItems, p -> {
             }));
         }
         if (itemAsOutput.isEmpty()) {
             ItemStack noItems = new ItemStack(Material.BARRIER);
             ItemUtils.setDisplayName(noItems, String.format("%sNo recipes output %s%s", ChatColor.RED, ChatColor.BOLD,
-                ItemUtils.getItemName(item)));
+                ChatUtils.translate(item)));
             itemAsOutput.add(new LClickable(noItems, p -> {
             }));
         }
@@ -168,7 +169,7 @@ public class ItemUseGUI {
         List<String> lore = new ArrayList<>();
         lore.add(ChatColor.GOLD + "Setup cost:");
         for (Map.Entry<ItemStack, Integer> entry : fccEgg.getSetupCost().getEntrySet()) {
-            String recipeRepresentation = entry.getValue() + " " + ItemUtils.getItemName(entry.getKey());
+            String recipeRepresentation = entry.getValue() + " " + ChatUtils.translate(entry.getKey());
             lore.add(formatIngredient(recipeRepresentation, item));
         }
         ItemUtils.addLore(is, lore);
@@ -176,7 +177,7 @@ public class ItemUseGUI {
     }
 
     private String formatIngredient(String recipeRepresentation, ItemStack is) {
-        if (recipeRepresentation.matches("\\d+ " + ItemUtils.getItemName(is))) {
+        if (recipeRepresentation.matches("\\d+ " + ChatUtils.translate(is))) {
             return String.format("%s - %s%s%s", ChatColor.GRAY, ChatColor.AQUA, ChatColor.BOLD, recipeRepresentation);
         } else {
             return String.format("%s - %s%s", ChatColor.GRAY, ChatColor.AQUA, recipeRepresentation);

--- a/plugins/finale-paper/src/main/java/com/github/maxopoly/finale/listeners/EnchantmentDisableListener.java
+++ b/plugins/finale-paper/src/main/java/com/github/maxopoly/finale/listeners/EnchantmentDisableListener.java
@@ -13,7 +13,7 @@ import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.inventory.ItemStack;
-import vg.civcraft.mc.civmodcore.inventory.items.EnchantUtils;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 
 public class EnchantmentDisableListener implements Listener {
 
@@ -34,7 +34,7 @@ public class EnchantmentDisableListener implements Listener {
             }
             item.removeEnchantment(enchant);
             owner.sendMessage(ChatColor.RED + "The enchantment "
-                + EnchantUtils.getEnchantNiceName(enchant) + " is disabled and has "
+                + ChatUtils.translate(enchant) + " is disabled and has "
                 + "been removed from your item!");
         }
     }

--- a/plugins/finale-paper/src/main/java/com/github/maxopoly/finale/overlay/ScoreboardHUD.java
+++ b/plugins/finale-paper/src/main/java/com/github/maxopoly/finale/overlay/ScoreboardHUD.java
@@ -20,8 +20,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
-import vg.civcraft.mc.civmodcore.inventory.items.PotionUtils;
 import vg.civcraft.mc.civmodcore.players.scoreboard.bottom.BottomLine;
 import vg.civcraft.mc.civmodcore.players.scoreboard.bottom.BottomLineAPI;
 import vg.civcraft.mc.civmodcore.players.scoreboard.side.CivScoreBoard;
@@ -170,9 +170,14 @@ public class ScoreboardHUD implements Listener {
             }
 
             //TODO check deprecated methods
-            String name = PotionUtils.getEffectNiceName(pot.getType());
-            String formatted = String.format("%s %s%s %d | %d:%s", sortingPrefix, effectColor, name, level, minutes,
-                seconds);
+            String formatted = "%s %s%s %d | %d:%s".formatted(
+                sortingPrefix,
+                effectColor,
+                ChatUtils.translate(pot.getType()),
+                level,
+                minutes,
+                seconds
+            );
             scoreBoards.get(boardIndex).set(p, formatted);
             boardIndex++;
         }

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/ExchangeRule.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/ExchangeRule.java
@@ -25,6 +25,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.InventoryUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.nbt.NBTSerialization;
@@ -280,7 +281,7 @@ public final class ExchangeRule implements ExchangeData {
         if (!Strings.isNullOrEmpty(listing)) {
             return listing;
         }
-        listing = ItemUtils.getItemName(this.material);
+        listing = ChatUtils.translate(this.material);
         if (!Strings.isNullOrEmpty(listing)) {
             return listing;
         }

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantModifier.java
@@ -32,6 +32,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.EnchantUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
@@ -113,15 +114,14 @@ public final class EnchantModifier extends ModifierData {
     public List<String> getDisplayInfo() {
         List<String> info = Lists.newArrayList();
         for (Map.Entry<Enchantment, Integer> requiredEnchant : getRequiredEnchants().entrySet()) {
-            String name = EnchantUtils.getEnchantNiceName(requiredEnchant.getKey());
             if (requiredEnchant.getValue() == ExchangeRule.ANY) {
-                info.add(ChatColor.AQUA + name);
+                info.add(ChatColor.AQUA + ChatUtils.translate(requiredEnchant.getKey()));
             } else {
-                info.add(ChatColor.AQUA + name + " " + requiredEnchant.getValue());
+                info.add(ChatColor.AQUA + ChatUtils.translate(requiredEnchant.getKey()) + " " + requiredEnchant.getValue());
             }
         }
         for (Enchantment excludedEnchant : getExcludedEnchants()) {
-            info.add(ChatColor.RED + "!" + EnchantUtils.getEnchantNiceName(excludedEnchant));
+            info.add(ChatColor.RED + "!" + ChatUtils.translate(excludedEnchant));
         }
         if (isAllowingUnlistedEnchants()) {
             info.add(ChatColor.GREEN + "Other enchantments allowed");

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantStorageModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantStorageModifier.java
@@ -17,6 +17,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.jetbrains.annotations.NotNull;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.EnchantUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 import vg.civcraft.mc.civmodcore.utilities.MoreMapUtils;
@@ -87,11 +88,10 @@ public final class EnchantStorageModifier extends ModifierData {
     public List<String> getDisplayInfo() {
         List<String> info = Lists.newArrayList();
         for (Map.Entry<Enchantment, Integer> entry : getEnchants().entrySet()) {
-            String name = EnchantUtils.getEnchantNiceName(entry.getKey());
             if (entry.getValue() == ExchangeRule.ANY) {
-                info.add(ChatColor.AQUA + name + " %");
+                info.add(ChatColor.AQUA + ChatUtils.translate(entry.getKey()) + " %");
             } else {
-                info.add(ChatColor.AQUA + name + " " + entry.getValue());
+                info.add(ChatColor.AQUA + ChatUtils.translate(entry.getKey()) + " " + entry.getValue());
             }
         }
         return info;

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/PotionModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/PotionModifier.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionType;
 import org.jetbrains.annotations.NotNull;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.items.PotionUtils;
 import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
 import vg.civcraft.mc.civmodcore.utilities.NullUtils;
@@ -125,7 +126,7 @@ public final class PotionModifier extends ModifierData {
         if (this.base == null) {
             return null;
         }
-        return PotionUtils.getPotionNiceName(this.base);
+        return ChatUtils.translate(PotionUtils.asTranslatable(this.base));
     }
 
     public PotionType getPotionType() {

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/gui/SnitchOverviewGUI.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/gui/SnitchOverviewGUI.java
@@ -43,28 +43,61 @@ public class SnitchOverviewGUI {
             ItemUtils.handleItemMeta(icon, (ItemMeta meta) -> {
                 meta.displayName(Component.text(snitch.getName(), NamedTextColor.GOLD));
                 final var location = snitch.getLocation();
-                List<Component> lore = new ArrayList<>();
-                lore.add(ChatUtils.newComponent("Location: ").color(NamedTextColor.AQUA)
-                    .append(Component.text(location.getWorld().getName() + " ").color(NamedTextColor.WHITE))
-                    .append(Component.text(location.getBlockX()).color(NamedTextColor.RED))
-                    .append(Component.text(", ").color(NamedTextColor.WHITE))
-                    .append(Component.text(location.getBlockY()).color(NamedTextColor.GREEN))
-                    .append(Component.text(", ").color(NamedTextColor.WHITE))
-                    .append(Component.text(location.getBlockZ()).color(NamedTextColor.BLUE)));
-                lore.add(ChatUtils.newComponent("Group: " + snitch.getGroup().getName()).color(NamedTextColor.YELLOW));
+                final var lore = new ArrayList<Component>();
+                lore.add(
+                    ChatUtils.nonItalic()
+                        .color(NamedTextColor.AQUA)
+                        .content("Location: ")
+                        .append(
+                            Component.text(location.getWorld().getName(), NamedTextColor.WHITE),
+                            Component.space(),
+                            Component.text(location.getBlockX(), NamedTextColor.RED),
+                            Component.text(", ", NamedTextColor.WHITE),
+                            Component.text(location.getBlockY(), NamedTextColor.GREEN),
+                            Component.text(", ", NamedTextColor.WHITE),
+                            Component.text(location.getBlockZ(), NamedTextColor.BLUE)
+                        )
+                        .build()
+                );
+                lore.add(
+                    ChatUtils.nonItalic()
+                        .color(NamedTextColor.YELLOW)
+                        .content("Group: " + snitch.getGroup().getName())
+                        .build()
+                );
                 if (snitch.hasAppender(DormantCullingAppender.class)) {
                     final var cull = snitch.getAppender(DormantCullingAppender.class);
                     if (cull.isActive()) {
-                        lore.add(ChatUtils.newComponent("Will go dormant in " + TextUtil.formatDuration(cull.getTimeUntilDormant())).color(NamedTextColor.AQUA));
+                        lore.add(
+                            ChatUtils.nonItalic()
+                                .color(NamedTextColor.AQUA)
+                                .content("Will go dormant in " + TextUtil.formatDuration(cull.getTimeUntilDormant()))
+                                .build()
+                        );
                         meta.setEnchantmentGlintOverride(true);
                     } else if (cull.isDormant()) {
-                        lore.add(ChatUtils.newComponent("Will cull in " + TextUtil.formatDuration(cull.getTimeUntilCulling())).color(NamedTextColor.AQUA));
+                        lore.add(
+                            ChatUtils.nonItalic()
+                                .color(NamedTextColor.AQUA)
+                                .content("Will cull in " + TextUtil.formatDuration(cull.getTimeUntilCulling()))
+                                .build()
+                        );
                     }
                 }
                 if (this.canShowDetails) {
-                    lore.add(ChatUtils.newComponent("Click to show details").color(NamedTextColor.GREEN));
+                    lore.add(
+                        ChatUtils.nonItalic()
+                            .color(NamedTextColor.GREEN)
+                            .content("Click to show details")
+                            .build()
+                    );
                 }
-                lore.add(ChatUtils.newComponent("Right click to send waypoint").color(NamedTextColor.GOLD));
+                lore.add(
+                    ChatUtils.nonItalic()
+                        .color(NamedTextColor.GOLD)
+                        .content("Right click to send waypoint")
+                        .build()
+                );
                 meta.lore(lore);
                 return true;
             });

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
@@ -7,9 +7,9 @@ import java.util.UUID;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.gui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventory.gui.IClickable;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 public class DestroyVehicleAction extends LoggablePlayerVictimAction {
 
@@ -40,7 +40,7 @@ public class DestroyVehicleAction extends LoggablePlayerVictimAction {
 
     @Override
     public String getChatRepresentationIdentifier() {
-        return "Broke " + ItemUtils.getItemName(getVehicle());
+        return "Broke " + ChatUtils.translate(getVehicle());
     }
 
 }

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
@@ -7,9 +7,9 @@ import java.util.UUID;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.gui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventory.gui.IClickable;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 public class EnterVehicleAction extends LoggablePlayerVictimAction {
 
@@ -40,7 +40,7 @@ public class EnterVehicleAction extends LoggablePlayerVictimAction {
 
     @Override
     public String getChatRepresentationIdentifier() {
-        return "Entered " + ItemUtils.getItemName(getVehicle());
+        return "Entered " + ChatUtils.translate(getVehicle());
     }
 
 }

--- a/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/actions/impl/ExitVehicleAction.java
+++ b/plugins/jukealert-paper/src/main/java/com/untamedears/jukealert/model/actions/impl/ExitVehicleAction.java
@@ -7,9 +7,9 @@ import java.util.UUID;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.gui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventory.gui.IClickable;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 public class ExitVehicleAction extends LoggablePlayerVictimAction {
 
@@ -40,7 +40,7 @@ public class ExitVehicleAction extends LoggablePlayerVictimAction {
 
     @Override
     public String getChatRepresentationIdentifier() {
-        return "Exited " + ItemUtils.getItemName(getVehicle());
+        return "Exited " + ChatUtils.translate(getVehicle());
     }
 
 }

--- a/plugins/realisticbiomes-paper/src/main/java/com/untamedears/realisticbiomes/growthconfig/PlantGrowthConfig.java
+++ b/plugins/realisticbiomes-paper/src/main/java/com/untamedears/realisticbiomes/growthconfig/PlantGrowthConfig.java
@@ -20,7 +20,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.event.Cancellable;
 import org.bukkit.inventory.ItemStack;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.utilities.TextUtil;
 import vg.civcraft.mc.civmodcore.world.WorldUtils;
 
@@ -88,7 +88,7 @@ public class PlantGrowthConfig extends AbstractGrowthConfig {
         double lightMultiplier = getLightMultiplier(b);
         StringBuilder sb = new StringBuilder();
         sb.append(ChatColor.GOLD);
-        sb.append(ItemUtils.getItemName(item));
+        sb.append(ChatUtils.translate(item));
         if (biomeGrowthConfig instanceof PersistentGrowthConfig) {
             long time = getPersistentGrowthTime(b);
             if (time == -1) {

--- a/plugins/realisticbiomes-paper/src/main/java/com/untamedears/realisticbiomes/utils/RealisticBiomesGUI.java
+++ b/plugins/realisticbiomes-paper/src/main/java/com/untamedears/realisticbiomes/utils/RealisticBiomesGUI.java
@@ -16,6 +16,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Biome;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.gui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventory.gui.IClickable;
 import vg.civcraft.mc.civmodcore.inventory.gui.components.ComponableInventory;
@@ -111,7 +112,7 @@ public class RealisticBiomesGUI {
             }
             for (Map.Entry<Material, Double> entry : plant.getSoilBoniPerLevel().entrySet()) {
                 lore.add(String.format("%sSoil Bonus: %s%s (%.2f)", ChatColor.DARK_AQUA,
-                    ChatColor.GRAY, ItemUtils.getItemName(entry.getKey()), entry.getValue()));
+                    ChatColor.GRAY, ChatUtils.translate(entry.getKey()), entry.getValue()));
             }
             if (plant.getMaximumSoilLayers() != 0) {
                 lore.add(String.format("%sMax Soil Layers: %s%d", ChatColor.DARK_AQUA,
@@ -123,7 +124,7 @@ public class RealisticBiomesGUI {
             }
             for (Map.Entry<Material, Double> entry : plant.getGreenHouseRates().entrySet()) {
                 lore.add(String.format("%sGreen House Rate: %s%s (%.2f)", ChatColor.DARK_AQUA,
-                    ChatColor.GRAY, ItemUtils.getItemName(entry.getKey()), entry.getValue()));
+                    ChatColor.GRAY, ChatUtils.translate(entry.getKey()), entry.getValue()));
             }
             ItemUtils.addLore(is, lore);
             IClickable click = new DecorationStack(is);

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -52,7 +52,7 @@ import org.bukkit.inventory.meta.SpawnEggMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 
 /**
  * This is a grab-bag class to hold any _tuning_ related configurations that impact the
@@ -243,7 +243,7 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
                         event.setCancelled(true);
                         player.sendMessage(config.getChunkLimitsExceededMessage()
                             .replaceAll("%Limit%", Integer.toString(limit))
-                            .replaceAll("%Material%", ItemUtils.getItemName(mat))
+                            .replaceAll("%Material%", ChatUtils.translate(mat))
                         );
                         return;
                     }

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/GoldBlockElevators.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/GoldBlockElevators.java
@@ -20,7 +20,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
-import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.players.settings.PlayerSettingAPI;
 import vg.civcraft.mc.civmodcore.players.settings.gui.MenuSection;
 import vg.civcraft.mc.civmodcore.players.settings.impl.BooleanSetting;
@@ -47,7 +47,7 @@ public class GoldBlockElevators extends BasicHack {
         if (elevatorBlock == null)
             elevatorBlock = Material.GOLD_BLOCK;
 
-        this.blockName = ItemUtils.getItemName(this.elevatorBlock).toLowerCase();
+        this.blockName = ChatUtils.translate(this.elevatorBlock).toLowerCase();
 
         if (this.blockName.startsWith("block of"))
             this.blockName = this.blockName.substring("block of ".length());


### PR DESCRIPTION
Prunes a lot of unused and deprecated utilities related to chat components, as well as improving others.

## Zero-Impact removals
- Removed `ChatUtils.COLOURS`
- Removed `ChatUtils.fromRGB()`
- Removed `ChatUtils.collapseColour()`
- Removed `ChatUtils.isNormalisedComponent()`
- Removed `ChatUtils.normaliseComponent()`
- Removed `ChatUtils.upgradeLegacyString()`
- Removed `ChatUtils.cloneComponent()`
- Removed `ChatUtils.createItemHoverEvent()`

## Replacements
- Removed `ChatUtils.stringify()`, `ItemUtils.getItemName()`, `PotionUtils.getPotionNiceName()`, and `PotionUtils.getEffectNiceName()` in favour of `ChatUtils.translate()`

- Removed `ChatUtils.newComponent()` in favour of `ChatUtils.nonItalic()`

## Cleanups
- Cleaned up `Componentify` and fixed a potential NPE.