### PR TITLE
Prevent stripping logs & copper from damaging reinforcement

### DIFF
--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/EntityListener.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/EntityListener.java
@@ -44,6 +44,7 @@ import vg.civcraft.mc.citadel.ReinforcementLogic;
 import vg.civcraft.mc.citadel.events.ReinforcementBypassEvent;
 import vg.civcraft.mc.citadel.model.Reinforcement;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.civmodcore.inventory.items.MoreTags;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.NameLayerPlugin;
@@ -113,6 +114,12 @@ public class EntityListener implements Listener {
             return;
         }
         if (ecbe.getBlock().getType() == Material.CAVE_VINES || ecbe.getBlock().getType() == Material.CAVE_VINES_PLANT) {
+            return;
+        }
+        if (MoreTags.LOGS.isTagged(ecbe.getBlock().getType())) {
+            return;
+        }
+        if (MoreTags.COPPER_BLOCKS.isTagged(ecbe.getBlock().getType())) {
             return;
         }
         ReinforcementLogic.damageReinforcement(rein, ReinforcementLogic.getDamageApplied(rein), ecbe.getEntity());


### PR DESCRIPTION
Stops players breaking their own reinforcement when stripping blocks on their group

It also stops being able to break logs/copper by stripping instead of breaking the block