### PR TITLE
add ability to set custom afk message

### DIFF
--- a/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/ChatStrings.java
+++ b/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/ChatStrings.java
@@ -1,5 +1,7 @@
 package vg.civcraft.mc.civchat2;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.ChatColor;
 
 public class ChatStrings {
@@ -48,7 +50,7 @@ public class ChatStrings {
 
     public final static String chatNotAfk = ChatColor.BLUE + "You are no longer AFK.";
 
-    public final static String chatPlayerAfk = ChatColor.AQUA + "That player is currently AFK.";
+    public final static Component chatPlayerAfk = Component.text("That player is currently AFK.", NamedTextColor.AQUA);
 
     public final static String chatGroupMessage = ChatColor.GRAY + "[%s] %s: " + ChatColor.WHITE + "%s";
 

--- a/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/CivChat2Manager.java
+++ b/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/CivChat2Manager.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -48,7 +50,7 @@ public class CivChat2Manager {
     // replyList has (playerName, whotoreplyto)
     private final HashMap<UUID, UUID> replyList;
 
-    private final Set<UUID> afkPlayers;
+    private final HashMap<UUID, Component> afkPlayers;
 
     private ScoreboardHUD scoreboardHUD;
 
@@ -68,7 +70,7 @@ public class CivChat2Manager {
         chatChannels = new HashMap<>();
         groupChatChannels = new HashMap<>();
         replyList = new HashMap<>();
-        afkPlayers = new HashSet<>();
+        afkPlayers = new HashMap<>();
         scoreboardHUD = new ScoreboardHUD();
     }
 
@@ -147,7 +149,7 @@ public class CivChat2Manager {
 
         if (isPlayerAfk(receiver)) {
             receiver.sendMessage(receiverMessage);
-            sender.sendMessage(parse(ChatStrings.chatPlayerAfk));
+            sender.sendMessage(getPlayerAfkMessage(receiver));
             return;
             // Player is ignoring the sender
         } else if (DBM.isIgnoringPlayer(receiver.getUniqueId(), sender.getUniqueId())) {
@@ -251,7 +253,8 @@ public class CivChat2Manager {
      */
     public boolean isPlayerAfk(Player player) {
         Preconditions.checkNotNull(player, "player");
-        return afkPlayers.contains(player.getUniqueId());
+
+        return afkPlayers.get(player.getUniqueId()) != null;
     }
 
     /**
@@ -260,11 +263,13 @@ public class CivChat2Manager {
      * @param player The player to change
      * @return The player AFK status
      */
-    public boolean setPlayerAfk(Player player, boolean afkStatus) {
+    public boolean setPlayerAfk(Player player, boolean afkStatus, Component afkMsg) {
         Preconditions.checkNotNull(player, "player");
+        Preconditions.checkNotNull(afkMsg, "afk message");
 
         if (afkStatus) {
-            afkPlayers.add(player.getUniqueId());
+            afkPlayers.put(player.getUniqueId(), afkMsg);
+            // afkPlayers.add(player.getUniqueId());
         } else {
             afkPlayers.remove(player.getUniqueId());
         }
@@ -279,18 +284,24 @@ public class CivChat2Manager {
      * @param player Player to toggle state for
      * @return Whether afk is turned on afterwards
      */
-    public boolean togglePlayerAfk(Player player) {
+    public boolean togglePlayerAfk(Player player, Component afkMsg) {
         Preconditions.checkNotNull(player, "player");
-        if (afkPlayers.contains(player.getUniqueId())) {
+        Preconditions.checkNotNull(afkMsg, "afk message");
+        if (isPlayerAfk(player)) {
             afkPlayers.remove(player.getUniqueId());
 
             scoreboardHUD.updateAFKScoreboardHUD(player);
             return false;
         }
-        afkPlayers.add(player.getUniqueId());
+        afkPlayers.put(player.getUniqueId(), afkMsg);
 
         scoreboardHUD.updateAFKScoreboardHUD(player);
         return true;
+    }
+
+    public Component getPlayerAfkMessage(Player player) {
+        Preconditions.checkNotNull(player, "player");
+        return afkPlayers.get(player.getUniqueId());
     }
 
     /**

--- a/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/commands/Afk.java
+++ b/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/commands/Afk.java
@@ -3,6 +3,10 @@ package vg.civcraft.mc.civchat2.commands;
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Optional;
+import co.aikar.commands.annotation.Syntax;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import vg.civcraft.mc.civchat2.ChatStrings;
 import vg.civcraft.mc.civchat2.CivChat2;
@@ -11,12 +15,21 @@ public class Afk extends BaseCommand {
 
     @CommandAlias("afk")
     @Description("Toggle afk status")
-    public void execute(Player player) {
-        boolean isAfk = CivChat2.getInstance().getCivChat2Manager().togglePlayerAfk(player);
-        if (isAfk) {
-            player.sendMessage(ChatStrings.chatAfk);
+    @Syntax("[message]")
+    public void execute(Player player, @Optional String afkMessageRaw) {
+        Component afkMessage;
+        if (afkMessageRaw == null) {
+            afkMessage = ChatStrings.chatPlayerAfk;
         } else {
-            player.sendMessage(ChatStrings.chatNotAfk);
+            afkMessage = Component.text(afkMessageRaw, NamedTextColor.AQUA);
         }
+
+        boolean isAfk = CivChat2.getInstance().getCivChat2Manager().togglePlayerAfk(player, afkMessage);
+        if (!isAfk) {
+            player.sendMessage(ChatStrings.chatNotAfk);
+            return;
+        }
+
+        player.sendMessage(ChatStrings.chatAfk);
     }
 }

--- a/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/commands/GlobalChat.java
+++ b/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/commands/GlobalChat.java
@@ -20,8 +20,6 @@ public class GlobalChat extends BaseCommand {
     @CommandAlias("global|globalchat")
     @Syntax("[message]")
     @Description("Enters global group chat or sends a message to global group chat")
-    @CommandCompletion("@CC_Groups @nothing")
-
     public void execute(Player player, @Optional String chatMessage) {
         String globalGroupName = CivChat2.getInstance().getPluginConfig().getGlobalChatGroupName();
         if (globalGroupName == null) {


### PR DESCRIPTION
Make a simple patch that lets players set a custom afk message. Still need to decide if the custom message should be added onto the default message or not.

Demo:
`/afk This is a highly custom message from a very dumb person, please forgive me my good sir`
![image](https://github.com/user-attachments/assets/c9ee5681-4cb2-47d2-8e75-1bcfc1bff366)
