### PR TITLE
Show pearl health value instead of percent

### DIFF
--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/ExilePearl.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/ExilePearl.java
@@ -124,13 +124,6 @@ public interface ExilePearl {
     int getHealth();
 
     /**
-     * Gets the pearl health percent value
-     *
-     * @return The health percent value
-     */
-    Integer getHealthPercent();
-
-    /**
      * Sets the pearl health value
      *
      * @param health The health value

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/command/CmdAdminSetHealth.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/command/CmdAdminSetHealth.java
@@ -11,10 +11,10 @@ public class CmdAdminSetHealth extends PearlCommand {
         super(pearlApi);
         this.aliases.add("sethealth");
 
-        this.setHelpShort("Sets the health % value of a pearl.");
+        this.setHelpShort("Sets the health value of a pearl.");
 
         this.commandArgs.add(requiredPearlPlayer());
-        this.commandArgs.add(required("health %", autoTab("", "Enter the desired health percent")));
+        this.commandArgs.add(required("health", autoTab("", "Enter the desired health")));
 
         this.permission = Permission.SET_HEALTH.node;
         this.visibility = CommandVisibility.SECRET;
@@ -34,17 +34,13 @@ public class CmdAdminSetHealth extends PearlCommand {
             return;
         }
 
-        Integer arg = argAsInt(1);
-        if (arg == null) {
-            msg("<b>Pearl health must be an integer between 0 and 100.");
+        Integer health = argAsInt(1);
+        if (health == null) {
+            msg("<b>Pearl health must be an integer");
             return;
         }
 
-        int percent = Math.min(100, Math.max(1, arg));
-
-        // calculate the actual value
-        int healthValue = (int) (plugin.getPearlConfig().getPearlHealthMaxValue() * ((double) percent / 100));
-        pearl.setHealth(healthValue);
-        msg("<g>You updated the pearl health of player %s to %d%%", pearl.getPlayerName(), percent);
+        pearl.setHealth(health);
+        msg("<g>You updated the pearl health of player %s to %d", pearl.getPlayerName(), health);
     }
 }

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
@@ -237,17 +237,6 @@ final class CoreExilePearl implements ExilePearl {
      * @return The strength value
      */
     @Override
-    public Integer getHealthPercent() {
-        return (int) Math.round(((double) health / pearlApi.getPearlConfig().getPearlHealthMaxValue()) * 100);
-    }
-
-
-    /**
-     * Gets the pearl health value
-     *
-     * @return The strength value
-     */
-    @Override
     public int getHealth() {
         return this.health;
     }

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
@@ -73,12 +73,15 @@ final class CoreLoreGenerator implements LoreProvider {
 
         lore.add(parse("<l>%s", pearl.getItemName()));
         lore.add(parse(PlayerNameStringFormat, pearl.getPlayerName(), Integer.toString(pearl.getPearlId(), 36).toUpperCase()));
-        lore.add(parse("<a>Health: <n>%s/%s", health, config.getPearlHealthMaxValue()));
         lore.add(parse("<a>Exiled on: <n>%s", dateFormat.format(pearl.getPearledOn())));
         lore.add(parse("<a>Killed by: <n>%s", pearl.getKillerName()));
         if (ExilePearlPlugin.getApi().isBanStickEnabled() && BanHandler.isPlayerBanned(pearl.getPlayerId())) {
             lore.add(parse("<b>Player is banned."));
         }
+
+        lore.add(parse(""));
+
+        lore.add(parse("<a>Health: <n>%s/%s", health, config.getPearlHealthMaxValue()));
         Set<RepairMaterial> repair = config.getRepairMaterials(pearl.getPearlType());
         if (repair != null) {
             for (RepairMaterial rep : repair) {

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
@@ -71,11 +71,9 @@ final class CoreLoreGenerator implements LoreProvider {
     private List<String> generateLoreInternal(ExilePearl pearl, int health, boolean addCommandHelp) {
         List<String> lore = new ArrayList<String>();
 
-        Integer healthPercent = Math.min(100, Math.max(0, (int) Math.round(((double) health / config.getPearlHealthMaxValue()) * 100)));
-
         lore.add(parse("<l>%s", pearl.getItemName()));
         lore.add(parse(PlayerNameStringFormat, pearl.getPlayerName(), Integer.toString(pearl.getPearlId(), 36).toUpperCase()));
-        lore.add(parse("<a>Health: <n>%s%%", healthPercent.toString()));
+        lore.add(parse("<a>Health: <n>%s/%s", health, config.getPearlHealthMaxValue()));
         lore.add(parse("<a>Exiled on: <n>%s", dateFormat.format(pearl.getPearledOn())));
         lore.add(parse("<a>Killed by: <n>%s", pearl.getKillerName()));
         if (ExilePearlPlugin.getApi().isBanStickEnabled() && BanHandler.isPlayerBanned(pearl.getPlayerId())) {
@@ -84,13 +82,13 @@ final class CoreLoreGenerator implements LoreProvider {
         Set<RepairMaterial> repair = config.getRepairMaterials(pearl.getPearlType());
         if (repair != null) {
             for (RepairMaterial rep : repair) {
-                int amountPerItem = rep.getRepairAmount();
+                double amountPerItem = rep.getRepairAmount() / pearl.getLongTimeMultiplier();
                 String item = rep.getStack().getType().toString();
                 if (rep.getStack().hasItemMeta() && rep.getStack().getItemMeta().hasDisplayName()) {
                     item = rep.getStack().getItemMeta().getDisplayName();
                 }
                 int damagesPerHumanInterval = (config.getPearlHealthDecayHumanIntervalMin() / config.getPearlHealthDecayIntervalMin()) * config.getPearlHealthDecayAmount(); // intervals in a human interval * damage per
-                int repairsPerHumanInterval = damagesPerHumanInterval / amountPerItem;
+                int repairsPerHumanInterval = (int) Math.ceil(damagesPerHumanInterval / amountPerItem);
                 lore.add(parse("<a>Cost per %s using %s:<n> %s", config.getPearlHealthDecayHumanInterval(), item, Integer.toString(repairsPerHumanInterval)));
             }
         }

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -1107,15 +1107,15 @@ public class PlayerListener implements Listener, Configurable {
             return;
         }
 
-        // Get the total possible repair amount. This doesn't need to be limited
-        // because the lore generator will cap at 100%
+        // Get the total possible repair amount and new health value
         int repairAmount = invItems.getAmount(repairItem.getStack()) * repairItem.getRepairAmount();
         repairAmount = (int) Math.ceil(repairAmount / pearl.getLongTimeMultiplier());
+        int newHealth = Math.min(pearlApi.getPearlConfig().getPearlHealthMaxValue(), pearl.getHealth() + repairAmount);
 
         // Generate a new item with the updated health value as the crafting result
         ItemStack resultStack = pearl.createItemStack();
         ItemMeta im = resultStack.getItemMeta();
-        im.setLore(pearlApi.getLoreProvider().generateLoreWithModifiedHealth(pearl, pearl.getHealth() + repairAmount));
+        im.setLore(pearlApi.getLoreProvider().generateLoreWithModifiedHealth(pearl, newHealth));
         resultStack.setItemMeta(im);
 
         e.getInventory().setResult(resultStack);
@@ -1146,11 +1146,12 @@ public class PlayerListener implements Listener, Configurable {
         // Quit if no repair items were found in the crafting inventory
         if (repairItem != null) {
             int maxHealth = pearlApi.getPearlConfig().getPearlHealthMaxValue();
-            int repairPerItem = repairItem.getRepairAmount();
             int repairMatsAvailable = invItems.getAmount(repairItem.getStack());
-            int repairMatsToUse = Math.min((int) Math.ceil((maxHealth - pearl.getHealth()) / (double) repairPerItem), repairMatsAvailable);
-            int repairAmount = repairMatsToUse * repairPerItem;
-            repairAmount = (int) Math.ceil(repairAmount / pearl.getLongTimeMultiplier());
+            int healthToFill = maxHealth - pearl.getHealth();
+            double repairPerItem = repairItem.getRepairAmount() / pearl.getLongTimeMultiplier();
+            int repairMatsToUse = Math.min((int) Math.ceil(healthToFill / repairPerItem), repairMatsAvailable);
+            int repairAmount = (int) (repairMatsToUse * repairPerItem);
+            int newHealth = Math.min(pearlApi.getPearlConfig().getPearlHealthMaxValue(), pearl.getHealth() + repairAmount);
 
             // Changing the value of the crafting items results in a dupe glitch so any remaining
             // materials need to be placed back into the player's inventory.
@@ -1178,7 +1179,7 @@ public class PlayerListener implements Listener, Configurable {
             inv.clear();
 
             // Repair the pearl and update the item stack
-            pearl.setHealth(pearl.getHealth() + repairAmount);
+            pearl.setHealth(newHealth);
             inv.setResult(pearl.createItemStack());
             pearlApi.log("The pearl for player %s was repaired by %d points.", pearl.getPlayerName(), repairAmount);
             return;


### PR DESCRIPTION
This PR Does not include any changes to pearl cost.

It only changes the way we display pearl health, showing the actual health value instead of a percentage.
Additionally, it updates the "Cost per day" to reflect how much of this health the pearl is actually using.

Fresh pearl:
![image](https://github.com/user-attachments/assets/c9dd0b6d-feae-4ca1-a0ea-9eeefb098510)

Refueling preview:
![image](https://github.com/user-attachments/assets/331cb6e2-7a26-41e3-b0fa-50a3c4c8dace)

Refueling output:
![image](https://github.com/user-attachments/assets/46e42943-09a0-4f8f-b40f-bc95eff53103)

Four year old pearl:
![image](https://github.com/user-attachments/assets/4a465a01-bf52-46c3-bdda-69e3ddaff615)
