### PR TITLE
Remove dependency on DecentHologams

### DIFF
--- a/plugins/citadel-paper/build.gradle.kts
+++ b/plugins/citadel-paper/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
 
     compileOnly(project(":plugins:civmodcore-paper"))
     compileOnly(project(":plugins:namelayer-paper"))
-    compileOnly("com.github.decentsoftware-eu:decentholograms:2.8.9")
+
+    compileOnly("com.comphenix.protocol:ProtocolLib:5.2.0-SNAPSHOT")
 }

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/Citadel.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/Citadel.java
@@ -148,14 +148,7 @@ public class Citadel extends ACivMod {
         stateManager = new PlayerStateManager();
         acidManager = new AcidManager(config.getAcidTypes());
         settingManager = new CitadelSettingManager();
-        Bukkit.getScheduler().scheduleSyncDelayedTask(this, () -> {
-            if (Bukkit.getPluginManager().isPluginEnabled("DecentHolograms")) {
-                holoManager = new HologramManager(settingManager);
-                logger.info("DecentHolograms is loaded, holograms available");
-            } else {
-                logger.info("DecentHolograms is not loaded, no holograms available");
-            }
-        });
+        holoManager = new HologramManager(settingManager);
         commandManager = new CitadelCommandManager(this);
         CitadelPermissionHandler.setup();
         registerListeners();

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/ModeListener.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/ModeListener.java
@@ -1,10 +1,14 @@
 package vg.civcraft.mc.citadel.listener;
 
+import java.awt.*;
 import java.text.DecimalFormat;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Color;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -12,8 +16,10 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.CitadelPermissionHandler;
 import vg.civcraft.mc.citadel.CitadelUtility;
@@ -178,6 +184,29 @@ public class ModeListener implements Listener {
             roundingFormat.format(rein.getHealth()), roundingFormat.format(rein.getType().getHealth()));
     }
 
+    public static Component formatHealthRgb(Reinforcement rein) {
+        double broken = rein.getHealth() / rein.getType().getHealth();
+        int slot = (int) (broken * 12);
+        TextColor colour = new TextColor[] {
+            TextColor.color(0xaa0000),
+            TextColor.color(0xaa1c00),
+            TextColor.color(0xaa3900),
+            TextColor.color(0xaa5500),
+            TextColor.color(0xaa7100),
+            TextColor.color(0xaa8e00),
+            TextColor.color(0xaaaa00),
+            TextColor.color(0x8eaa00),
+            TextColor.color(0x71aa00),
+            TextColor.color(0x55aa00),
+            TextColor.color(0x39aa00),
+            TextColor.color(0x1caa00),
+            TextColor.color(0x00aa00),
+        }[slot];
+        return Component.text(String.format("%s%% (%s/%s)",
+            commaFormat.format(rein.getHealth() / rein.getType().getHealth() * 100),
+            roundingFormat.format(rein.getHealth()), roundingFormat.format(rein.getType().getHealth())), colour);
+    }
+
     public static String formatProgress(long start, long timeNeeded, String text) {
         long timeTaken = System.currentTimeMillis() - start;
         timeTaken = Math.min(timeTaken, timeNeeded);
@@ -273,6 +302,22 @@ public class ModeListener implements Listener {
             return;
         }
         showHolo(rein, player);
+    }
+
+    @EventHandler
+    public void on(PlayerQuitEvent event) {
+        HologramManager holoManager = Citadel.getInstance().getHologramManager();
+        if (holoManager != null) {
+            holoManager.deleteHolos(event.getPlayer());
+        }
+    }
+
+    @EventHandler
+    public void on(PlayerChangedWorldEvent event) {
+        HologramManager holoManager = Citadel.getInstance().getHologramManager();
+        if (holoManager != null) {
+            holoManager.deleteHolos(event.getPlayer());
+        }
     }
 
     private static void showHolo(Reinforcement rein, Player player) {

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/ModeListener.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/ModeListener.java
@@ -199,8 +199,8 @@ public class ModeListener implements Listener {
             TextColor.color(0x71aa00),
             TextColor.color(0x55aa00),
             TextColor.color(0x39aa00),
-            TextColor.color(0x1caa00),
-            TextColor.color(0x00aa00),
+            TextColor.color(0x68f84c),
+            TextColor.color(0x55ff00),
         }[slot];
         return Component.text(String.format("%s%% (%s/%s)",
             commaFormat.format(rein.getHealth() / rein.getType().getHealth() * 100),

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/model/HologramManager.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/model/HologramManager.java
@@ -1,5 +1,12 @@
 package vg.civcraft.mc.citadel.model;
 
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.wrappers.WrappedDataValue;
+import com.comphenix.protocol.wrappers.WrappedDataWatcher;
+import io.papermc.paper.adventure.AdventureComponent;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -9,20 +16,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
-import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLibrary;
-import com.comphenix.protocol.ProtocolManager;
-import com.comphenix.protocol.events.PacketContainer;
-import com.comphenix.protocol.wrappers.WrappedDataValue;
-import com.comphenix.protocol.wrappers.WrappedDataWatcher;
-import io.papermc.paper.adventure.AdventureComponent;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.serializer.ComponentSerializer;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -114,9 +110,7 @@ public class HologramManager {
         private long timeStamp;
         private boolean hasPermission;
         private Location cachedPlayerLocation;
-        private double cachedHealth;
         private long cullDelay;
-        private List<String> content;
 
         public PlayerHolo(Player player, Reinforcement reinforcement) {
             this.player = player;

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/model/HologramManager.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/model/HologramManager.java
@@ -9,10 +9,22 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
-import eu.decentsoftware.holograms.api.DHAPI;
-import eu.decentsoftware.holograms.api.holograms.Hologram;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.wrappers.WrappedDataValue;
+import com.comphenix.protocol.wrappers.WrappedDataWatcher;
+import io.papermc.paper.adventure.AdventureComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.ComponentSerializer;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
@@ -59,6 +71,17 @@ public class HologramManager {
         holo.show();
     }
 
+    public void deleteHolos(Player player) {
+        for (Map.Entry<Location, Map<UUID, PlayerHolo>> entry : holograms.entrySet()) {
+            Map<UUID, PlayerHolo> map = entry.getValue();
+            PlayerHolo holo = map.get(player.getUniqueId());
+            if (holo != null) {
+                holo.delete();
+                map.remove(player.getUniqueId());
+            }
+        }
+    }
+
     private static Location getHoloLocation(Reinforcement rein, Player player) {
         Location baseLoc = rein.getBlockCenter();
         baseLoc = baseLoc.add(0, 0.5, 0);
@@ -86,13 +109,14 @@ public class HologramManager {
     private class PlayerHolo {
 
         private Player player;
-        private Hologram hologram;
+        private int hologramId;
         private Reinforcement reinforcement;
         private long timeStamp;
         private boolean hasPermission;
         private Location cachedPlayerLocation;
         private double cachedHealth;
         private long cullDelay;
+        private List<String> content;
 
         public PlayerHolo(Player player, Reinforcement reinforcement) {
             this.player = player;
@@ -107,30 +131,78 @@ public class HologramManager {
 
         void show() {
             refreshTimestamp();
-            if (hologram != null) {
+            if (hologramId != 0) {
                 return;
             }
-            List<String> lines = createHoloContent(); // Create with content to avoid entity spawn delay
-            hologram = DHAPI.createHologram("citadel-hologram-" + this.hashCode(), getHoloLocation(reinforcement, player), lines);
+
+            this.hologramId = Bukkit.getUnsafe().nextEntityId();
+
+            ProtocolManager protocolLib = ProtocolLibrary.getProtocolManager();
+            PacketContainer fakeEntity = protocolLib.createPacket(PacketType.Play.Server.SPAWN_ENTITY);
+            Location location = getHoloLocation(reinforcement, player);
+            fakeEntity.getIntegers()
+                .write(0, hologramId)
+                .write(1, 0)
+                .write(2, 0)
+                .write(3, 0)
+                .write(4, 0);
+
+            fakeEntity.getUUIDs().write(0, UUID.randomUUID());
+
+            fakeEntity.getEntityTypeModifier()
+                .write(0, EntityType.TEXT_DISPLAY);
+
+            fakeEntity.getDoubles()
+                .write(0, location.getX())
+                .write(1, location.getY())
+                .write(2, location.getZ());
+
+            fakeEntity.getBytes()
+                .write(0, (byte) 0)
+                .write(1, (byte) 0)
+                .write(2, (byte) 0);
+
+            protocolLib.sendServerPacket(player, fakeEntity);
+            sendUpdatePacket();
             cachedPlayerLocation = player.getLocation();
-            hologram.setDefaultVisibleState(false);
-            hologram.setShowPlayer(player);
         }
 
-        private List<String> createHoloContent() {
-            List<String> lines = new ArrayList<>();
-            lines.add(ModeListener.formatHealth(reinforcement));
+        private void sendUpdatePacket() {
+            ProtocolManager protocolLib = ProtocolLibrary.getProtocolManager();
+
+            PacketContainer fakeMetadata = protocolLib.createPacket(PacketType.Play.Server.ENTITY_METADATA);
+            fakeMetadata.getIntegers().write(0, hologramId);
+
+            List<WrappedDataValue> values = new ArrayList<>();
+            values.add(new WrappedDataValue(10, WrappedDataWatcher.Registry.get(Integer.class), 2));
+            values.add(new WrappedDataValue(15, WrappedDataWatcher.Registry.get(Byte.class), (byte) 3));
+            values.add(new WrappedDataValue(23, WrappedDataWatcher.Registry.getChatComponentSerializer(),
+                new AdventureComponent(createHoloContent())));
+            values.add(new WrappedDataValue(25, WrappedDataWatcher.Registry.get(Integer.class), 0));
+            // Add shadow when MC-260529 is fixed
+            values.add(new WrappedDataValue(27, WrappedDataWatcher.Registry.get(Byte.class), (byte) (0x02)));
+            fakeMetadata.getDataValueCollectionModifier().write(0, values);
+
+            protocolLib.sendServerPacket(player, fakeMetadata);
+        }
+
+        private Component createHoloContent() {
+            Component component = Component.empty();
+            component = component.append(ModeListener.formatHealthRgb(reinforcement)).append(Component.newline());
             if (hasPermission) {
-                lines.add(ChatColor.LIGHT_PURPLE + reinforcement.getGroup().getName());
-                lines.add(ChatColor.AQUA + reinforcement.getType().getName());
+                component = component.append(Component.text(reinforcement.getGroup().getName(), NamedTextColor.LIGHT_PURPLE)).append(Component.newline());
+                component = component.append(Component.text(reinforcement.getType().getName(), NamedTextColor.AQUA));
                 if (!reinforcement.isMature()) {
-                    lines.add(ModeListener.formatProgress(reinforcement.getCreationTime(), reinforcement.getType().getMaturationTime(), ""));
+                    component = component.append(Component.newline()).append(Component.text(ModeListener.formatProgress(reinforcement.getCreationTime(), reinforcement.getType().getMaturationTime(), ""), NamedTextColor.GRAY));
                 }
             }
-            return lines;
+            return component;
         }
 
         boolean update() {
+            if (hologramId == 0) {
+                return false;
+            }
             if (System.currentTimeMillis() - timeStamp > cullDelay) {
                 delete();
                 return false;
@@ -140,7 +212,7 @@ public class HologramManager {
                 return false;
             }
             updateLocation();
-            DHAPI.setHologramLines(hologram, createHoloContent());
+            sendUpdatePacket();
             return true;
         }
 
@@ -152,7 +224,24 @@ public class HologramManager {
                 return;
             }
             Location updated = getHoloLocation(reinforcement, player);
-            hologram.setLocation(updated);
+            ProtocolManager protocolLib = ProtocolLibrary.getProtocolManager();
+
+            PacketContainer fakeTeleport = protocolLib.createPacket(PacketType.Play.Server.ENTITY_TELEPORT);
+            fakeTeleport.getIntegers().write(0, hologramId);
+
+            fakeTeleport.getDoubles()
+                .write(0, updated.getX())
+                .write(1, updated.getY())
+                .write(2, updated.getZ());
+
+            fakeTeleport.getBytes()
+                .write(0, (byte) 0)
+                .write(1, (byte) 0);
+
+            fakeTeleport.getBooleans()
+                .write(0, false);
+
+            protocolLib.sendServerPacket(player, fakeTeleport);
         }
 
         void refreshTimestamp() {
@@ -160,8 +249,16 @@ public class HologramManager {
         }
 
         void delete() {
-            hologram.delete();
-            hologram = null;
+            if (hologramId == 0) {
+                return;
+            }
+            ProtocolManager protocolLib = ProtocolLibrary.getProtocolManager();
+
+            PacketContainer fakeDestroy = protocolLib.createPacket(PacketType.Play.Server.ENTITY_DESTROY);
+            fakeDestroy.getIntLists().write(0, List.of(hologramId));
+
+            protocolLib.sendServerPacket(player, fakeDestroy);
+            hologramId = 0;
         }
 
     }

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/model/HologramManager.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/model/HologramManager.java
@@ -172,7 +172,7 @@ public class HologramManager {
             values.add(new WrappedDataValue(15, WrappedDataWatcher.Registry.get(Byte.class), (byte) 3));
             values.add(new WrappedDataValue(23, WrappedDataWatcher.Registry.getChatComponentSerializer(),
                 new AdventureComponent(createHoloContent())));
-            values.add(new WrappedDataValue(25, WrappedDataWatcher.Registry.get(Integer.class), 0));
+//            values.add(new WrappedDataValue(25, WrappedDataWatcher.Registry.get(Integer.class), 0));
             // Add shadow when MC-260529 is fixed
             values.add(new WrappedDataValue(27, WrappedDataWatcher.Registry.get(Byte.class), (byte) (0x02)));
             fakeMetadata.getDataValueCollectionModifier().write(0, values);

--- a/plugins/citadel-paper/src/main/resources/plugin.yml
+++ b/plugins/citadel-paper/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ authors:
   - Rourke750
   - Maxopoly
   - ProgrammerDan
-  - okx-code
+  - Okx
   - Cranite
   - FeatherCrown
   - Lazersmoke
@@ -15,7 +15,7 @@ depend:
   - NameLayer
   - CivModCore
 softdepend:
-  - HolographicDisplays
+  - ProtocolLib
 description: Citadel allows you to make blocks difficult to break. When a block is reinforced, it must be broken many times before it is destroyed.
 api-version: 1.21.1
 permissions:

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/TextUtil.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/TextUtil.java
@@ -27,11 +27,11 @@ public final class TextUtil {
         }
         if (minutes > 0) {
             sb.append(minutes);
-            sb.append(" min ");
+            sb.append("m ");
         }
         if (seconds > 0) {
             sb.append(seconds);
-            sb.append(" sec");
+            sb.append("s");
         }
         return sb.toString().trim();
     }


### PR DESCRIPTION
It is not suited to our needs: we need to modify it to support displaying a hologram to a single player, and shows holograms with a bit of a delay.

Instead, we can use Text Displays, added in 1.19.4, and send them with packets.

Unfortunately, this will slightly change how the background is displayed. Either it is a single rectangle covering the full max width, or no background. I opted to remove the background.

It would be nice to have better contrast for the text with no background, but due to [MC-260529](https://bugs.mojang.com/browse/MC-260529) we cannot add a shadow and still have the hologam visible through blocks.