### PR TITLE
Fix  ambiguous essence claim message

### DIFF
--- a/plugins/essenceglue-paper/src/main/java/com/github/maxopoly/essenceglue/reward/VirtualRewarder.java
+++ b/plugins/essenceglue-paper/src/main/java/com/github/maxopoly/essenceglue/reward/VirtualRewarder.java
@@ -23,6 +23,6 @@ public class VirtualRewarder implements Rewarder {
         player.sendMessage(Component.empty().color(EssenceCommand.NICE_BLUE)
             .append(Component.text("Use "))
             .append(Component.text("/essence withdraw", NamedTextColor.AQUA))
-            .append(Component.text(" to claim your essence.")));
+            .append(Component.text(" to materialise all of your essence as an item.")));
     }
 }


### PR DESCRIPTION
Before:
>  Use /essence withdraw to claim your essence.

After:

 > Use /essence withdraw to materialise all of your essence as an item.

"Claim" implies that if i do not run the proposed command I will not receive the daily essence and that the command will only apply to the essence that I've just received, not to all the essence in my pouch.

I simply used the already existing wording from https://github.com/CivMC/Civ/blob/main/plugins/essenceglue-paper/src/main/java/com/github/maxopoly/essenceglue/commands/EssenceCommand.java#L36