### PR TITLE
Add ItemExchange receipts

### DIFF
--- a/ansible/files/paper-config/plugins/ItemExchange/config.yml
+++ b/ansible/files/paper-config/plugins/ItemExchange/config.yml
@@ -141,3 +141,6 @@ shopRelay:
     - GREEN_STAINED_GLASS_PANE
     - RED_STAINED_GLASS_PANE
     - BLACK_STAINED_GLASS_PANE
+
+receipts:
+  enabled: false

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/ChatUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/ChatUtils.java
@@ -9,6 +9,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
@@ -310,6 +311,36 @@ public final class ChatUtils {
     public static Component upgradeLegacyString(@Nullable final String string) {
         return string == null ? null : string.isEmpty() ? Component.empty() :
             LegacyComponentSerializer.legacySection().deserialize(string);
+    }
+
+    /**
+     * Creates a new component builder that is explicitly non-italic, good for item display components like display
+     * names and lore.
+     */
+    public static @NotNull TextComponent.Builder nonItalic() {
+        return Component.text()
+            .decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE);
+    }
+
+    /**
+     * Creates a new component builder that is explicitly non-italic, good for item display components like display
+     * names and lore.
+     */
+    public static @NotNull TextComponent.Builder nonItalic(
+        final @NotNull String content
+    ) {
+        return nonItalic().content(content);
+    }
+
+    /**
+     * Creates a new component builder that is explicitly non-italic, good for item display components like display
+     * names and lore.
+     */
+    public static @NotNull TextComponent.Builder nonItalic(
+        final @NotNull String content,
+        final @NotNull TextColor color
+    ) {
+        return nonItalic(content).color(color);
     }
 
     /**

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeConfig.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeConfig.java
@@ -29,6 +29,7 @@ public final class ItemExchangeConfig extends ConfigParser {
     private static int RELAY_REACH_DISTANCE;
     private static final Set<Material> RELAY_PERMEABLE_BLOCKS = new HashSet<>();
     private static ShapelessRecipe BULK_RULE_RECIPE;
+    private static boolean RECEIPTS;
 
     public ItemExchangeConfig(final ItemExchangePlugin plugin) {
         super(plugin);
@@ -42,6 +43,7 @@ public final class ItemExchangeConfig extends ConfigParser {
         parseCreateFromShop(config.getBoolean("createShopFromChest", true));
         parseRepairableItems(config.getStringList("repairables"));
         parseShopRelay(config.getConfigurationSection("shopRelay"));
+        parseReceipts(config.getConfigurationSection("receipts"));
         return true;
     }
 
@@ -213,6 +215,17 @@ public final class ItemExchangeConfig extends ConfigParser {
         }
     }
 
+    private void parseReceipts(
+        final ConfigurationSection config
+    ) {
+        if (config == null) {
+            LOGGER.info("Skipping receipt parsing: section is missing.");
+            return;
+        }
+        RECEIPTS = config.getBoolean("enabled");
+        LOGGER.info("Receipts enabled: {}", RECEIPTS);
+    }
+
     // ------------------------------------------------------------
     // Getters
     // ------------------------------------------------------------
@@ -287,4 +300,7 @@ public final class ItemExchangeConfig extends ConfigParser {
         return RELAY_PERMEABLE_BLOCKS.contains(material);
     }
 
+    public static boolean areReceiptsEnabled() {
+        return RECEIPTS;
+    }
 }

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeListener.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeListener.java
@@ -213,34 +213,36 @@ public final class ItemExchangeListener implements Listener {
         } else {
             player.sendMessage(ChatColor.GREEN + "Successful donation!");
         }
-        // Generate and give the player a receipt of the transaction
-        final ReceiptModifier receiptModifier = Objects.requireNonNullElseGet(
-            inputRule.getModifiers().get(ReceiptModifier.class),
-            ReceiptModifier::new
-        );
-        if (ItemExchangeSettings.RECEIVE_RECEIPTS.getValue(player) || receiptModifier.forceReceiptGeneration) {
-            final ItemStack receiptItem = ReceiptUtils.generateReceipt(
-                player,
-                clicked,
-                trade.getBlock(),
-                inputRule,
-                outputRule,
-                receiptModifier.footerText
+        if (ItemExchangeConfig.areReceiptsEnabled()) {
+            // Generate and give the player a receipt of the transaction
+            final ReceiptModifier receiptModifier = Objects.requireNonNullElseGet(
+                inputRule.getModifiers().get(ReceiptModifier.class),
+                ReceiptModifier::new
             );
-            Utilities.giveItemsOrDrop(player.getInventory(), receiptItem);
-            player.sendMessage(
-                Component.text()
-                    .color(NamedTextColor.GREEN)
-                    .content("You have been given a ")
-                    .append(
-                        Component.text()
-                            .decoration(TextDecoration.ITALIC, TextDecoration.State.TRUE)
-                            .decoration(TextDecoration.UNDERLINED, TextDecoration.State.TRUE)
-                            .content("receipt")
-                            .hoverEvent(receiptItem.asHoverEvent()),
-                        Component.text("!")
-                    )
-            );
+            if (ItemExchangeSettings.RECEIVE_RECEIPTS.getValue(player) || receiptModifier.forceReceiptGeneration) {
+                final ItemStack receiptItem = ReceiptUtils.generateReceipt(
+                    player,
+                    clicked,
+                    trade.getBlock(),
+                    inputRule,
+                    outputRule,
+                    receiptModifier.footerText
+                );
+                Utilities.giveItemsOrDrop(player.getInventory(), receiptItem);
+                player.sendMessage(
+                    Component.text()
+                        .color(NamedTextColor.GREEN)
+                        .content("You have been given a ")
+                        .append(
+                            Component.text()
+                                .decoration(TextDecoration.ITALIC, TextDecoration.State.TRUE)
+                                .decoration(TextDecoration.UNDERLINED, TextDecoration.State.TRUE)
+                                .content("receipt")
+                                .hoverEvent(receiptItem.asHoverEvent()),
+                            Component.text("!")
+                        )
+                );
+            }
         }
     }
 

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangePlugin.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangePlugin.java
@@ -12,7 +12,9 @@ import com.untamedears.itemexchange.rules.modifiers.EnchantModifier;
 import com.untamedears.itemexchange.rules.modifiers.EnchantStorageModifier;
 import com.untamedears.itemexchange.rules.modifiers.LoreModifier;
 import com.untamedears.itemexchange.rules.modifiers.PotionModifier;
+import com.untamedears.itemexchange.rules.modifiers.ReceiptModifier;
 import com.untamedears.itemexchange.rules.modifiers.RepairModifier;
+import com.untamedears.itemexchange.utility.ReceiptUtils;
 import java.util.List;
 import vg.civcraft.mc.civmodcore.ACivMod;
 import vg.civcraft.mc.civmodcore.commands.CommandManager;
@@ -52,8 +54,11 @@ public final class ItemExchangePlugin extends ACivMod implements AutoCloseable {
         modifiers.registerModifier(DamageableModifier.TEMPLATE); // 500
         modifiers.registerModifier(RepairModifier.TEMPLATE); // 600
         modifiers.registerModifier(BookModifier.TEMPLATE); // 1000
+        modifiers.registerModifier(ReceiptModifier.TEMPLATE); // Short.MAX
         registerListener(new ItemExchangeListener());
         this.glues.forEach(DependencyGlue::registerGlue);
+        ReceiptUtils.init();
+        ItemExchangeSettings.init();
     }
 
     @Override

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeSettings.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeSettings.java
@@ -16,7 +16,7 @@ public final class ItemExchangeSettings {
 
     public static final BooleanSetting RECEIVE_RECEIPTS = new BooleanSetting(
         ItemExchangePlugin.getInstance(),
-        true,
+        false,
         "Receive receipts?",
         "ie_receive_receipts",
         "Would you like your purchases to print a receipt? (Some exchanges will always produce a receipt regardless of this setting!)"

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeSettings.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeSettings.java
@@ -1,0 +1,29 @@
+package com.untamedears.itemexchange;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+import vg.civcraft.mc.civmodcore.players.settings.PlayerSettingAPI;
+import vg.civcraft.mc.civmodcore.players.settings.gui.MenuSection;
+import vg.civcraft.mc.civmodcore.players.settings.impl.BooleanSetting;
+
+public final class ItemExchangeSettings {
+    public static final MenuSection MAIN_MENU = PlayerSettingAPI.getMainMenu().createMenuSection(
+        "ItemExchange",
+        "Settings for ItemExchange",
+        new ItemStack(Material.CHEST)
+    );
+
+    public static final BooleanSetting RECEIVE_RECEIPTS = new BooleanSetting(
+        ItemExchangePlugin.getInstance(),
+        true,
+        "Receive receipts?",
+        "ie_receive_receipts",
+        "Would you like your purchases to print a receipt? (Some exchanges will always produce a receipt regardless of this setting!)"
+    );
+
+    @ApiStatus.Internal
+    public static void init() {
+        PlayerSettingAPI.registerSetting(RECEIVE_RECEIPTS, MAIN_MENU);
+    }
+}

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/commands/SetCommand.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/commands/SetCommand.java
@@ -6,14 +6,19 @@ import co.aikar.commands.annotation.CatchUnknown;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.Single;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.untamedears.itemexchange.rules.ExchangeRule;
+import com.untamedears.itemexchange.rules.modifiers.ReceiptModifier;
+import com.untamedears.itemexchange.utility.ModifierHandler;
 import com.untamedears.itemexchange.utility.RuleHandler;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 @CommandAlias(SetCommand.ALIAS)
@@ -72,4 +77,84 @@ public final class SetCommand extends BaseCommand {
         }
     }
 
+    // ------------------------------------------------------------
+    // Receipts
+    // ------------------------------------------------------------
+
+    @Subcommand("receipt")
+    @Description("Adds or removes a receipt modifier from an exchange rule.")
+    public void toggleReceiptModifier(
+        final @NotNull Player sender
+    ) {
+        try (final var handler = new ModifierHandler<>(sender, ReceiptModifier.TEMPLATE)) {
+            if (handler.getModifier() == null) {
+                handler.ensureModifier();
+                switch (handler.getRule().getType()) {
+                    case INPUT -> handler.relay(ChatColor.GREEN + "Added receipt modifier!");
+                    case OUTPUT -> handler.relay(ChatColor.GOLD + "Added receipt modifier, but it will only work if you swap this rule to an input!");
+                }
+            }
+            else {
+                handler.setModifier(null);
+                handler.relay(ChatColor.GREEN + "Removed receipt modifier!");
+            }
+        }
+    }
+
+    @Subcommand("receipt alwaysprint|forceprint")
+    @Description("Toggles whether to override customer preferences and always give a receipt. (Will create modifier if it doesn't already exist)")
+    public void toggleForcedReceipts(
+        final @NotNull Player sender
+    ) {
+        try (final var handler = new ModifierHandler<>(sender, ReceiptModifier.TEMPLATE)) {
+            final ReceiptModifier modifier = handler.ensureModifier();
+            if (modifier.forceReceiptGeneration) {
+                modifier.forceReceiptGeneration = false;
+                handler.relay(ChatColor.GREEN + "Customers will now only be given receipts if preferred!");
+            }
+            else {
+                modifier.forceReceiptGeneration = true;
+                handler.relay(ChatColor.GREEN + "Customers will now be given receipts regardless of preference!");
+            }
+        }
+    }
+
+    @Subcommand("receipt footer|slogan clear")
+    @Description("Resets any footer/slogan text.")
+    public void resetReceiptFooter(
+        final @NotNull Player sender
+    ) {
+        try (final var handler = new ModifierHandler<>(sender, ReceiptModifier.TEMPLATE)) {
+            final ReceiptModifier modifier = handler.getModifier();
+            if (modifier == null) {
+                handler.relay(ChatColor.GREEN + "That rule doesn't have a receipt modifier!");
+                return;
+            }
+            if (modifier.footerText == null) {
+                handler.relay(ChatColor.GREEN + "Receipt modifier already has no footer text!");
+                return;
+            }
+            modifier.footerText = null;
+            handler.relay(ChatColor.GREEN + "Receipt modifier footer text has been reset!");
+        }
+    }
+
+    @Subcommand("receipt footer|slogan set")
+    @Description("Sets or resets any footer/slogan text. (Will create modifier if it doesn't already exist)")
+    public void setReceiptFooter(
+        final @NotNull Player sender,
+        final @Optional String footer
+    ) {
+        try (final var handler = new ModifierHandler<>(sender, ReceiptModifier.TEMPLATE)) {
+            final ReceiptModifier modifier = handler.ensureModifier();
+            if (StringUtils.isBlank(footer)) {
+                modifier.footerText = null;
+                handler.relay(ChatColor.GREEN + "Reset receipt footer text!");
+            }
+            else {
+                modifier.footerText = footer;
+                handler.relay(ChatColor.GREEN + "Receipt footer text set!");
+            }
+        }
+    }
 }

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/commands/SetCommand.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/commands/SetCommand.java
@@ -10,10 +10,13 @@ import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.Single;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
+import com.untamedears.itemexchange.ItemExchangeConfig;
 import com.untamedears.itemexchange.rules.ExchangeRule;
 import com.untamedears.itemexchange.rules.modifiers.ReceiptModifier;
 import com.untamedears.itemexchange.utility.ModifierHandler;
 import com.untamedears.itemexchange.utility.RuleHandler;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -88,6 +91,11 @@ public final class SetCommand extends BaseCommand {
     ) {
         try (final var handler = new ModifierHandler<>(sender, ReceiptModifier.TEMPLATE)) {
             if (handler.getModifier() == null) {
+                // Putting it here so players can remove receipt modifiers if receipts are disabled at a later date
+                if (!ItemExchangeConfig.areReceiptsEnabled()) {
+                    sender.sendMessage(Component.text("Receipts are not enabled!", NamedTextColor.RED));
+                    return;
+                }
                 handler.ensureModifier();
                 switch (handler.getRule().getType()) {
                     case INPUT -> handler.relay(ChatColor.GREEN + "Added receipt modifier!");
@@ -106,6 +114,10 @@ public final class SetCommand extends BaseCommand {
     public void toggleForcedReceipts(
         final @NotNull Player sender
     ) {
+        if (!ItemExchangeConfig.areReceiptsEnabled()) {
+            sender.sendMessage(Component.text("Receipts are not enabled!", NamedTextColor.RED));
+            return;
+        }
         try (final var handler = new ModifierHandler<>(sender, ReceiptModifier.TEMPLATE)) {
             final ReceiptModifier modifier = handler.ensureModifier();
             if (modifier.forceReceiptGeneration) {
@@ -124,6 +136,10 @@ public final class SetCommand extends BaseCommand {
     public void resetReceiptFooter(
         final @NotNull Player sender
     ) {
+        if (!ItemExchangeConfig.areReceiptsEnabled()) {
+            sender.sendMessage(Component.text("Receipts are not enabled!", NamedTextColor.RED));
+            return;
+        }
         try (final var handler = new ModifierHandler<>(sender, ReceiptModifier.TEMPLATE)) {
             final ReceiptModifier modifier = handler.getModifier();
             if (modifier == null) {
@@ -145,6 +161,10 @@ public final class SetCommand extends BaseCommand {
         final @NotNull Player sender,
         final @Optional String footer
     ) {
+        if (!ItemExchangeConfig.areReceiptsEnabled()) {
+            sender.sendMessage(Component.text("Receipts are not enabled!", NamedTextColor.RED));
+            return;
+        }
         try (final var handler = new ModifierHandler<>(sender, ReceiptModifier.TEMPLATE)) {
             final ReceiptModifier modifier = handler.ensureModifier();
             if (StringUtils.isBlank(footer)) {

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/glues/namelayer/GroupModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/glues/namelayer/GroupModifier.java
@@ -8,6 +8,7 @@ import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.untamedears.itemexchange.ItemExchangeListener;
 import com.untamedears.itemexchange.commands.SetCommand;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.ModifierHandler;
@@ -68,7 +69,9 @@ public final class GroupModifier extends ModifierData {
     }
 
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         return List.of(isBroken() ?
             ChatColor.RED + "BROKEN GROUP MODIFIER" :
             "Group: " + this.groupName);

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/ExchangeRule.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/ExchangeRule.java
@@ -3,6 +3,7 @@ package com.untamedears.itemexchange.rules;
 import com.google.common.base.Strings;
 import com.untamedears.itemexchange.ItemExchangeConfig;
 import com.untamedears.itemexchange.ItemExchangePlugin;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import com.untamedears.itemexchange.rules.interfaces.ExchangeData;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.rules.modifiers.DisplayNameModifier;
@@ -337,20 +338,24 @@ public final class ExchangeRule implements ExchangeData {
         return builder.toString();
     }
 
-    private List<String> getRuleDetails() {
+    private List<String> getRuleDetails(
+        final @NotNull DisplayContext context
+    ) {
         List<String> info = new ArrayList<>();
         this.modifiers.stream()
-            .map(ModifierData::getDisplayInfo)
+            .map((modifier) -> modifier.getDisplayInfo(context))
             .filter(CollectionUtils::isNotEmpty)
             .forEachOrdered(info::addAll);
         return info;
     }
 
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         List<String> info = new ArrayList<>();
         info.add(getRuleTitle());
-        info.addAll(getRuleDetails());
+        info.addAll(getRuleDetails(context));
         return info;
     }
 
@@ -443,7 +448,7 @@ public final class ExchangeRule implements ExchangeData {
 
         ItemUtils.handleItemMeta(item, (ItemMeta meta) -> {
             meta.setDisplayName(getRuleTitle());
-            meta.setLore(getRuleDetails());
+            meta.setLore(getRuleDetails(DisplayContext.BUTTON_LORE));
             return true;
         });
         return item;

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/ShopRule.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/ShopRule.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Sets;
 import com.untamedears.itemexchange.ItemExchangeConfig;
 import com.untamedears.itemexchange.ItemExchangePlugin;
 import com.untamedears.itemexchange.events.BlockInventoryRequestEvent;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -86,11 +87,11 @@ public final class ShopRule implements Validation {
         }
         player.sendMessage(String.format("%s(%d/%d) exchanges present.",
             ChatColor.YELLOW, this.currentTradeIndex + 1, this.trades.size()));
-        for (String line : trade.getInput().getDisplayInfo()) {
+        for (String line : trade.getInput().getDisplayInfo(DisplayContext.CHAT_OUTPUT)) {
             player.sendMessage(line);
         }
         if (trade.getOutput() != null) {
-            for (String line : trade.getOutput().getDisplayInfo()) {
+            for (String line : trade.getOutput().getDisplayInfo(DisplayContext.CHAT_OUTPUT)) {
                 player.sendMessage(line);
             }
             PLUGIN.debug("[ShopRule] Calculating stock.");

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/interfaces/DisplayContext.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/interfaces/DisplayContext.java
@@ -1,0 +1,6 @@
+package com.untamedears.itemexchange.rules.interfaces;
+
+public enum DisplayContext {
+    BUTTON_LORE,
+    CHAT_OUTPUT
+}

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/interfaces/ExchangeData.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/interfaces/ExchangeData.java
@@ -2,6 +2,7 @@ package com.untamedears.itemexchange.rules.interfaces;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.nbt.NBTSerializable;
 import vg.civcraft.mc.civmodcore.utilities.Validation;
 
@@ -16,7 +17,9 @@ public interface ExchangeData extends Validation, NBTSerializable {
      *
      * @return Returns any display information.
      */
-    default List<String> getDisplayInfo() {
+    default List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         return new ArrayList<>(0);
     }
 

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/interfaces/ModifierData.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/interfaces/ModifierData.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang.IllegalClassException;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.nbt.NBTSerializable;
 import vg.civcraft.mc.civmodcore.nbt.NBTSerialization;
@@ -96,7 +97,9 @@ public abstract class ModifierData extends BaseCommand
      * are supported and convey to not list anything.
      */
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         return null;
     }
 

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/BookModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/BookModifier.java
@@ -3,6 +3,7 @@ package com.untamedears.itemexchange.rules.modifiers;
 import co.aikar.commands.annotation.CommandAlias;
 import com.google.common.base.Strings;
 import com.untamedears.itemexchange.commands.SetCommand;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import java.util.ArrayList;
@@ -133,7 +134,9 @@ public final class BookModifier extends ModifierData {
     }
 
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         final var lines = new ArrayList<String>(2);
         if (hasAuthor()) {
             lines.add(ChatColor.DARK_AQUA + "Author: " + ChatColor.GRAY + getAuthor());

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/DamageableModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/DamageableModifier.java
@@ -10,6 +10,7 @@ import co.aikar.commands.annotation.Syntax;
 import com.google.common.base.Strings;
 import com.untamedears.itemexchange.commands.SetCommand;
 import com.untamedears.itemexchange.rules.ExchangeRule;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.ModifierHandler;
@@ -89,7 +90,9 @@ public final class DamageableModifier extends ModifierData {
     }
 
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         int ruleDamage = getDamage();
         switch (ruleDamage) {
             case ExchangeRule.ANY:

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantModifier.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.untamedears.itemexchange.commands.SetCommand;
 import com.untamedears.itemexchange.rules.ExchangeRule;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.ModifierHandler;
@@ -110,7 +111,9 @@ public final class EnchantModifier extends ModifierData {
     }
 
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         List<String> info = Lists.newArrayList();
         for (Map.Entry<Enchantment, Integer> requiredEnchant : getRequiredEnchants().entrySet()) {
             String name = EnchantUtils.getEnchantNiceName(requiredEnchant.getKey());

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantStorageModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantStorageModifier.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.untamedears.itemexchange.commands.SetCommand;
 import com.untamedears.itemexchange.rules.ExchangeRule;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.NBTEncodings;
@@ -84,7 +85,9 @@ public final class EnchantStorageModifier extends ModifierData {
     }
 
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         List<String> info = Lists.newArrayList();
         for (Map.Entry<Enchantment, Integer> entry : getEnchants().entrySet()) {
             String name = EnchantUtils.getEnchantNiceName(entry.getKey());

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/LoreModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/LoreModifier.java
@@ -8,6 +8,7 @@ import co.aikar.commands.annotation.Syntax;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.untamedears.itemexchange.commands.SetCommand;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.ModifierHandler;
@@ -80,7 +81,9 @@ public final class LoreModifier extends ModifierData {
     }
 
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         return this.lore.stream()
             .map(line -> "" + ChatColor.DARK_PURPLE + ChatColor.ITALIC + line)
             .collect(Collectors.toCollection(ArrayList::new));

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/PotionModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/PotionModifier.java
@@ -4,6 +4,7 @@ import co.aikar.commands.annotation.CommandAlias;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.untamedears.itemexchange.commands.SetCommand;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.NBTEncodings;
@@ -107,7 +108,9 @@ public final class PotionModifier extends ModifierData {
     }
 
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         return Collections.singletonList(ChatColor.AQUA + "Potion Name: " + ChatColor.WHITE + getName());
     }
 

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/ReceiptModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/ReceiptModifier.java
@@ -1,0 +1,84 @@
+package com.untamedears.itemexchange.rules.modifiers;
+
+import co.aikar.commands.annotation.CommandAlias;
+import com.untamedears.itemexchange.commands.SetCommand;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
+import com.untamedears.itemexchange.rules.interfaces.Modifier;
+import com.untamedears.itemexchange.rules.interfaces.ModifierData;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.ChatColor;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import vg.civcraft.mc.civmodcore.nbt.wrappers.NBTCompound;
+
+@CommandAlias(SetCommand.ALIAS)
+@Modifier(slug = "RECEIPT", order = Short.MAX_VALUE)
+public final class ReceiptModifier extends ModifierData {
+    public static final ReceiptModifier TEMPLATE = new ReceiptModifier();
+
+    @Override
+    public @Nullable ReceiptModifier construct(
+        final @NotNull ItemStack item
+    ) {
+        return null; // Receipts are not a default modifier
+    }
+
+    @Override
+    public boolean isBroken() {
+        return false;
+    }
+
+    @Override
+    public boolean conforms(
+        final @NotNull ItemStack item
+    ) {
+        return true; // Have no effect on the matching of the item
+    }
+
+    @Override
+    public String getDisplayListing() {
+        return null; // Have no effect on listing names
+    }
+
+    private static final String FORCE_RECEIPT_GEN_KEY = "force_receipt";
+    private static final String FOOTER_TEXT_KEY = "force_receipt";
+
+    public boolean forceReceiptGeneration;
+    public String footerText;
+
+    @Override
+    public void toNBT(
+        final @NotNull NBTCompound nbt
+    ) {
+        nbt.setBoolean(FORCE_RECEIPT_GEN_KEY, this.forceReceiptGeneration);
+        nbt.setString(FOOTER_TEXT_KEY, this.footerText);
+    }
+
+    public static @NotNull ReceiptModifier fromNBT(
+        final @NotNull NBTCompound nbt
+    ) {
+        final var modifier = new ReceiptModifier();
+        modifier.forceReceiptGeneration = nbt.getBoolean(FORCE_RECEIPT_GEN_KEY);
+        modifier.footerText = nbt.getNullableString(FOOTER_TEXT_KEY);
+        return modifier;
+    }
+
+    @Override
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
+        final var info = new ArrayList<String>();
+        if (this.forceReceiptGeneration) {
+            info.add(ChatColor.GOLD + "Will produce a receipt regardless.");
+        }
+        if (context == DisplayContext.BUTTON_LORE) {
+            if (StringUtils.isNotBlank(this.footerText)) {
+                info.add(ChatColor.GOLD + "Footer: " + ChatColor.LIGHT_PURPLE + ChatColor.ITALIC + this.footerText);
+            }
+        }
+        return info;
+    }
+}

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/RepairModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/RepairModifier.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Lists;
 import com.untamedears.itemexchange.ItemExchangeConfig;
 import com.untamedears.itemexchange.commands.SetCommand;
 import com.untamedears.itemexchange.rules.ExchangeRule;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
 import com.untamedears.itemexchange.utility.ModifierHandler;
@@ -86,7 +87,9 @@ public final class RepairModifier extends ModifierData {
     }
 
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         List<String> info = Lists.newArrayList();
         int repairCost = getRepairCost();
         if (repairCost == 0) {

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/_ExampleModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/_ExampleModifier.java
@@ -3,6 +3,7 @@ package com.untamedears.itemexchange.rules.modifiers;
 import co.aikar.commands.annotation.CommandAlias;
 import com.untamedears.itemexchange.commands.SetCommand;
 import com.untamedears.itemexchange.rules.ExchangeRule;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
 import com.untamedears.itemexchange.rules.interfaces.ExchangeData;
 import com.untamedears.itemexchange.rules.interfaces.Modifier;
 import com.untamedears.itemexchange.rules.interfaces.ModifierData;
@@ -100,7 +101,9 @@ public final class _ExampleModifier extends ModifierData {
      * empty lists are supported and convey to not list anything.
      */
     @Override
-    public List<String> getDisplayInfo() {
+    public List<String> getDisplayInfo(
+        final @NotNull DisplayContext context
+    ) {
         return null;
     }
 

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/ReceiptUtils.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/ReceiptUtils.java
@@ -1,0 +1,124 @@
+package com.untamedears.itemexchange.utility;
+
+import com.untamedears.itemexchange.rules.ExchangeRule;
+import com.untamedears.itemexchange.rules.interfaces.DisplayContext;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import vg.civcraft.mc.civmodcore.chat.ChatUtils;
+import vg.civcraft.mc.civmodcore.chat.Componentify;
+import vg.civcraft.mc.civmodcore.inventory.CustomItem;
+import vg.civcraft.mc.civmodcore.inventory.items.MetaUtils;
+
+public final class ReceiptUtils {
+    private static final ItemStack RECEIPT_ITEM; static {
+        RECEIPT_ITEM = new ItemStack(Material.STONE_BUTTON);
+        final ItemMeta meta = RECEIPT_ITEM.getItemMeta();
+        meta.itemName(ChatUtils.nonItalic("Exchange Receipt", NamedTextColor.GOLD).build());
+        meta.setCustomModelData(-44_054_986);
+        RECEIPT_ITEM.setItemMeta(meta);
+    }
+
+    public static void init() {
+        CustomItem.registerCustomItem("ie_receipt", RECEIPT_ITEM);
+    }
+
+    /**
+     * @param shopBlock The block the purchaser interacted with when interacting with the shop.
+     *
+     * @param stockBlock The block the exchange originated from (where the input items will be deposited into, and
+     *                   output items withdrawn from). Relays mean this may be different from 'shopBlock'.
+     *
+     * @param footer Should be provided by the {@link com.untamedears.itemexchange.rules.modifiers.ReceiptModifier} on
+     *               the input rule.
+     */
+    public static @NotNull ItemStack generateReceipt(
+        final @NotNull Player purchaser,
+        final @NotNull Block shopBlock,
+        final @NotNull Block stockBlock,
+        final @NotNull ExchangeRule inputRule,
+        final ExchangeRule outputRule,
+        final String footer
+    ) {
+        final ItemStack receipt = RECEIPT_ITEM.clone();
+        final ItemMeta meta = receipt.getItemMeta();
+        final List<Component> lore = MetaUtils.getComponentLore(meta);
+        lore.addAll(List.of(
+            ChatUtils.nonItalic()
+                .append(Component.text("Purchaser: ", NamedTextColor.YELLOW))
+                .append(purchaser.name().color(NamedTextColor.WHITE))
+                .build(),
+            ChatUtils.nonItalic()
+                .append(Component.text("Timestamp: ", NamedTextColor.YELLOW))
+                .append(Component.text(formatTimestamp(System.currentTimeMillis()), NamedTextColor.LIGHT_PURPLE))
+                .build(),
+            ChatUtils.nonItalic()
+                .append(Component.text("Shop block: ", NamedTextColor.YELLOW))
+                .append(Componentify.blockLocation(shopBlock.getLocation()).color(NamedTextColor.WHITE))
+                .build(),
+            ChatUtils.nonItalic()
+                .append(Component.text("Shop hash: ", NamedTextColor.YELLOW))
+                .append(Component.text(formatShopHash(stockBlock), NamedTextColor.GRAY))
+                .build(),
+            Component.space()
+        ));
+        addRuleLore(lore, inputRule);
+        if (outputRule != null) {
+            lore.add(Component.space());
+            addRuleLore(lore, outputRule);
+        }
+        if (StringUtils.isNotBlank(footer)) {
+            lore.addAll(List.of(
+                Component.space(),
+                Component.text(footer, NamedTextColor.GOLD)
+            ));
+        }
+        lore.addAll(List.of(
+            Component.space(),
+            Component.text(UUID.randomUUID().toString())
+        ));
+        meta.lore(lore);
+        receipt.setItemMeta(meta);
+        return receipt;
+    }
+
+    /**
+     * Appends the typical chat-output to the item-lore, prefixed with a single space.
+     */
+    private static void addRuleLore(
+        final @NotNull List<@NotNull Component> lore,
+        final @NotNull ExchangeRule rule
+    ) {
+        for (final String line : rule.getDisplayInfo(DisplayContext.CHAT_OUTPUT)) {
+            lore.add(LegacyComponentSerializer.legacySection().deserialize(" " + line).decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE));
+        }
+    }
+
+    /**
+     * @return Returns a formatted timestamp, eg: Tue, 3 Jun 2008 11:05:30 GMT
+     */
+    private static @NotNull String formatTimestamp(
+        final long timestamp
+    ) {
+        return DateTimeFormatter.RFC_1123_DATE_TIME.format(Instant.ofEpochMilli(timestamp).atOffset(ZoneOffset.UTC));
+    }
+
+    private static @NotNull String formatShopHash(
+        final @NotNull Block stockBlock
+    ) {
+        return "#" + Integer.toHexString(stockBlock.getLocation().hashCode()).toUpperCase();
+    }
+}

--- a/plugins/itemexchange-paper/src/main/resources/config.yml
+++ b/plugins/itemexchange-paper/src/main/resources/config.yml
@@ -106,3 +106,6 @@ shopRelay:
     - "VOID_AIR"
     - "WATER"
     - "LAVA"
+
+receipts:
+  enabled: true


### PR DESCRIPTION
This implements [this suggestion](https://discord.com/channels/912074050086502470/1313232152263000156/1313232152263000156). It adds a new setting to `/config` (defaulted to `true`) which lets users decide whether to receive receipts for their ItemExchange purchases. This setting can be overridden-to-true by the `ReceiptModifier` modifier.

The receipt contains the following information:

- `Purchaser`
- `Timestamp` of purchase (pretty printed)
- `Shop block`: the block-location of the relay/shop-chest punched to use the shop
- `Shop hash`: the `.hashCode()` of the block-location of the container hosting the exchange itself, and where the input item(s) will be deposited into, and the output item(s), if any, are withdrawn from.
- The "input" chat-display for the exchange.
- The "output" chat display for the exchange, if any.
- Any footer text / slogan set on the `ReceiptModifier`.
- A receipt-unique UUID.

This adds the following commands:

- `/ies receipt`: This will toggle having a `ReceiptModifier` on the held exchange rule.
- `/ies receipt alwaysprint`: This will toggle whether to always print receipts, regardless of customer preference, on the held exchange rule.
- `/ies receipt footer clear`: Clears any set footer-text on the held exchange rule.
- `/ies receipt footer set <text>`: Sets footer-text on the held exchange rule.

In addition, receipts are given the custom-model id of `-44_054_986` (just a random int) so that modders can easily assign it a custom texture.

---

While this does ["dupe"](https://discord.com/channels/912074050086502470/952314898317189120/1314411805149233243) items, receipts are just stone buttons (like exchange rules themselves), which are perhaps one of the cheapest items in the game and can already be "duped" with `/iec`.