### PR TITLE
Faction permissions support

### DIFF
--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/NameLayerPlugin.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/NameLayerPlugin.java
@@ -8,6 +8,7 @@ import java.util.logging.Level;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import vg.civcraft.mc.civmodcore.ACivMod;
+import vg.civcraft.mc.namelayer.permission.LuckPermsIntegration;
 import vg.civcraft.mc.civmodcore.dao.DatabaseCredentials;
 import vg.civcraft.mc.civmodcore.dao.ManagedDatasource;
 import vg.civcraft.mc.namelayer.command.CommandHandler;
@@ -61,6 +62,9 @@ public class NameLayerPlugin extends ACivMod {
                 defaultGroupHandler = new DefaultGroupHandler();
                 autoAcceptHandler = new AutoAcceptHandler(groupManagerDao.loadAllAutoAccept());
                 handle = new CommandHandler(this);
+                
+                // Initialize LuckPerms integration
+                LuckPermsIntegration.initialize();
             }
         }
     }

--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/command/commands/CreateGroup.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/command/commands/CreateGroup.java
@@ -17,6 +17,7 @@ import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.RunnableOnGroup;
 import vg.civcraft.mc.namelayer.command.BaseCommandMiddle;
 import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.LuckPermsIntegration;
 
 public class CreateGroup extends BaseCommandMiddle {
 
@@ -80,11 +81,18 @@ public class CreateGroup extends BaseCommandMiddle {
                 if (p != null) {
                     if (g.getGroupId() == -1) { // failure
                         p.sendMessage(ChatColor.RED + "That group is already taken or creation failed.");
+                    } else {
+                        p.sendMessage(ChatColor.GREEN + "The group " + g.getName() + " was successfully created.");
+                        // Add LuckPerms integration
+                        LuckPermsIntegration.createGroupPermission(g.getName());
+                        LuckPermsIntegration.addPlayerToGroup(g.getName(), uuid);
                     }
-                    p.sendMessage(ChatColor.GREEN + "The group " + g.getName() + " was successfully created.");
                 } else {
                     NameLayerPlugin.getInstance().getLogger().log(Level.INFO, "Group {0} creation complete resulting in group id: {1}",
                         new Object[]{g.getName(), g.getGroupId()});
+                    // Add LuckPerms integration even if player is offline
+                    LuckPermsIntegration.createGroupPermission(g.getName());
+                    LuckPermsIntegration.addPlayerToGroup(g.getName(), uuid);
                 }
             }
         }, false);

--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/command/commands/DeleteGroup.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/command/commands/DeleteGroup.java
@@ -16,6 +16,7 @@ import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.BaseCommandMiddle;
 import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.LuckPermsIntegration;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
 public class DeleteGroup extends BaseCommandMiddle {
@@ -49,9 +50,14 @@ public class DeleteGroup extends BaseCommandMiddle {
                     //if it has been less than 15 seconds
                     if (now.getTime() < Long.parseLong(entry[1])) {
                         //good to go delete the group
-                        if (gm.deleteGroup(gD.getName()))
+                        if (gm.deleteGroup(gD.getName())) {
                             p.sendMessage(Component.text("Group was successfully deleted.").color(NamedTextColor.GREEN));
-                        else
+                            
+                            // Remove LuckPerms permissions for all members
+                            for (UUID memberId : gD.getAllMembers()) {
+                                LuckPermsIntegration.removePlayerFromGroup(gD.getName(), memberId);
+                            }
+                        } else
                             p.sendMessage(Component.text("Group is now disciplined. Check back later to see if group is deleted.").color(NamedTextColor.GREEN));
 
                         confirmDeleteGroup.remove(uuid);

--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/group/Group.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/group/Group.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
+import vg.civcraft.mc.namelayer.permission.LuckPermsIntegration;
 
 public class Group {
 
@@ -58,6 +59,8 @@ public class Group {
             List<UUID> list = db.getAllMembers(name, permission);
             for (UUID uuid : list) {
                 players.put(uuid, permission);
+                // Ensure LuckPerms permissions are set for existing members
+                LuckPermsIntegration.addPlayerToGroup(name, uuid);
             }
         }
 
@@ -407,6 +410,9 @@ public class Group {
             db.addMember(uuid, name, type);
         }
         players.put(uuid, type);
+        
+        // Add LuckPerms permission
+        LuckPermsIntegration.addPlayerToGroup(name, uuid);
     }
 
     /**
@@ -423,6 +429,9 @@ public class Group {
             db.removeMember(uuid, name);
         }
         players.remove(uuid);
+        
+        // Remove LuckPerms permission
+        LuckPermsIntegration.removePlayerFromGroup(name, uuid);
     }
 
     public void removeAllMembers() {
@@ -430,6 +439,12 @@ public class Group {
     }
 
     public void removeAllMembers(boolean savetodb) {
+        // Remove LuckPerms permissions for all members before clearing
+        List<UUID> members = new ArrayList<>(players.keySet());
+        for (UUID uuid : members) {
+            LuckPermsIntegration.removePlayerFromGroup(name, uuid);
+        }
+        
         if (savetodb) {
             db.removeAllMembers(this.name);
         }

--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/permission/LuckPermsIntegration.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/permission/LuckPermsIntegration.java
@@ -1,0 +1,106 @@
+package vg.civcraft.mc.namelayer.permission;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.node.Node;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+import java.util.UUID;
+import vg.civcraft.mc.namelayer.NameLayerPlugin;
+
+public class LuckPermsIntegration {
+    private static LuckPerms luckPerms;
+
+    public static void initialize() {
+        RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
+        if (provider != null) {
+            luckPerms = provider.getProvider();
+            NameLayerPlugin.getInstance().getLogger().info("LuckPerms integration initialized successfully");
+        } else {
+            NameLayerPlugin.getInstance().getLogger().warning("Failed to initialize LuckPerms integration - provider not found");
+        }
+    }
+
+    public static void createGroupPermission(String groupName) {
+        if (luckPerms == null) {
+            NameLayerPlugin.getInstance().getLogger().warning("Failed to create permission for group " + groupName + " - LuckPerms not initialized");
+            return;
+        }
+        String permission = "faction." + groupName.toLowerCase();
+        NameLayerPlugin.getInstance().getLogger().info("Permission node created and ready for use: " + permission);
+        // We don't actually need to create anything in LuckPerms - the permission node will be created
+        // automatically when it's first assigned to a user
+    }
+
+    public static void removeGroupPermission(String groupName, UUID playerUuid) {
+        if (luckPerms == null) {
+            NameLayerPlugin.getInstance().getLogger().warning("Failed to remove permission for player " + playerUuid + " - LuckPerms not initialized");
+            return;
+        }
+        String permission = "faction." + groupName.toLowerCase();
+        NameLayerPlugin.getInstance().getLogger().info("Removing permission node " + permission + " from player " + playerUuid);
+
+        // Always try to load the user, don't rely on cached version
+        try {
+            var userFuture = luckPerms.getUserManager().loadUser(playerUuid);
+            var user = userFuture.get(); // Wait for completion
+            if (user != null) {
+                // Create the node to remove
+                Node node = Node.builder(permission)
+                    .value(true)
+                    .build();
+                
+                // Remove the permission
+                user.data().remove(node);
+                
+                // Save the changes
+                luckPerms.getUserManager().saveUser(user);
+                
+                NameLayerPlugin.getInstance().getLogger().info("Successfully removed permission node " + permission + " from player " + playerUuid);
+            } else {
+                NameLayerPlugin.getInstance().getLogger().warning("Failed to remove permission - user could not be loaded: " + playerUuid);
+            }
+        } catch (Exception e) {
+            NameLayerPlugin.getInstance().getLogger().warning("Failed to load user for permission removal: " + playerUuid + " - " + e.getMessage());
+        }
+    }
+
+    public static void addPlayerToGroup(String groupName, UUID playerUuid) {
+        if (luckPerms == null) {
+            NameLayerPlugin.getInstance().getLogger().warning("Failed to add permission for player " + playerUuid + " - LuckPerms not initialized");
+            return;
+        }
+        String permission = "faction." + groupName.toLowerCase();
+        NameLayerPlugin.getInstance().getLogger().info("Adding permission node " + permission + " to player " + playerUuid);
+
+        // Always try to load the user, don't rely on cached version
+        try {
+            var userFuture = luckPerms.getUserManager().loadUser(playerUuid);
+            var user = userFuture.get(); // Wait for completion
+            if (user != null) {
+                // Create a new node with the permission
+                Node node = Node.builder(permission)
+                    .value(true)
+                    .build();
+                
+                // Remove any existing version of this permission first
+                user.data().remove(node);
+                // Add the new permission
+                user.data().add(node);
+                
+                // Save the changes
+                luckPerms.getUserManager().saveUser(user);
+                
+                NameLayerPlugin.getInstance().getLogger().info("Successfully added permission node " + permission + " to player " + playerUuid);
+            } else {
+                NameLayerPlugin.getInstance().getLogger().warning("Failed to add permission - user could not be loaded: " + playerUuid);
+            }
+        } catch (Exception e) {
+            NameLayerPlugin.getInstance().getLogger().warning("Failed to load user for permission addition: " + playerUuid + " - " + e.getMessage());
+        }
+    }
+
+    public static void removePlayerFromGroup(String groupName, UUID playerUuid) {
+        removeGroupPermission(groupName, playerUuid);
+    }
+}

--- a/plugins/namelayer-paper/src/main/resources/plugin.yml
+++ b/plugins/namelayer-paper/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: vg.civcraft.mc.namelayer.NameLayerPlugin
 version: ${version}
 author: Rourke750
 authors: [ BlackXnt, Maxopoly, ProgrammerDan, Tyrothalos, Scuwr, Mr_Little_Kitty ]
-depend: [ CivModCore ]
+depend: [ CivModCore, LuckPerms ]
 api-version: 1.21.1
 description: NameLayer handles groups creation and management, in addition to name changes. Once you have connected to Civcraft with a name, it is permanently yours. If a name is already taken, then NameLayer will add a number to the name.
 permissions:


### PR DESCRIPTION
AI created code changes, only basic testing done so far.  Requires review.

This change creates faction.[groupName] permissions for namelayer groups, adds the permission to a user when they are added to a group and removes the permission when they are removed.  This change will allow MythicMobs mobs to target based on namelayer group membership.