### PR TITLE
Too many turtles

### DIFF
--- a/ansible/files/paper-config/plugins/MobLimit/config.yml
+++ b/ansible/files/paper-config/plugins/MobLimit/config.yml
@@ -15,3 +15,8 @@ reasons:
   egg:
     chicken:
       dumb: true
+  natural:
+    turtle:
+      count: 8
+      # The radius to check for
+      radius: 32


### PR DESCRIPTION
Sets a natural spawning limit on turtles. if there's more than 8 in a 32 block radius. 