### PR TITLE
Update DestinationCommand.java to suggest OneDest structure

### DIFF
--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/commands/DestinationCommand.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/commands/DestinationCommand.java
@@ -5,6 +5,7 @@ import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.Syntax;
+import co.aikar.commands.annotation.CommandCompletion;
 import org.bukkit.entity.Player;
 import sh.okx.railswitch.settings.SettingsManager;
 
@@ -16,6 +17,7 @@ public final class DestinationCommand extends BaseCommand {
     @CommandAlias("dest|destination|setdestination|switch|setswitch|setsw")
     @Description("Set your rail destination(s)")
     @Syntax("[destination]")
+    @CommandCompletion("! +,-|+,+|-,+|-,- Impendia|Moloka|Lyrean|MtA|Medi|Arctic|AP|Deluvia|Founders|Proxima|Icenia|Karydia")
     public void onSetDestination(Player player, @Optional String destination) {
         SettingsManager.setDestination(player, destination);
     }


### PR DESCRIPTION
With this feature when writing /dest the command helper would suggest in the following order: 
!
+,-  +,+  -,+  or  -,- (quadrant)
Impendia Moloka  Lyrean  MtA  Medi  Arctic  AP  Deluvia  Founders  Proxima  Icenia  or  Karydia (region)

OneDest follows a tree structure that I don't know how to apply to the commandCompletion. It would be preferable so anybody puts a region that is not in the input quadrant. Onedest tree can be found here: https://github.com/OneDest/data/blob/master/tree.txt

Though, if not possible/too complicated, I think that my solution is already helpful