### PR TITLE
Factorymod additions. 

### DIFF
--- a/ansible/files/paper-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/paper-config/plugins/FactoryMod/config.yml
@@ -1708,22 +1708,7 @@ factories:
         v: 3839
         ==: org.bukkit.inventory.ItemStack
         type: COPPER_BLOCK
-        amount: 64
-      exposed_copper:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: EXPOSED_COPPER
-        amount: 64
-      weathered_copper:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: WEATHERED_COPPER
-        amount: 64
-      oxidized_copper:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: OXIDIZED_COPPER
-        amount: 64
+        amount: 256
       honeycomb:
         v: 3839
         ==: org.bukkit.inventory.ItemStack

--- a/ansible/files/paper-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/paper-config/plugins/FactoryMod/config.yml
@@ -245,7 +245,9 @@ factories:
       - facet_heliodor
       - refill_heliodor
       - finish_heliodor
+      - make_gem_kit
       - repair_gem_factory
+      - repair_gem_factory_kit
   stone_smelter:
     type: FCC
     name: Basic Smelter
@@ -478,7 +480,9 @@ factories:
       - cook_salmon
       - cook_cactus
       - cook_kelp
+      - make_grill_kit
       - repair_grill
+      - repair_grill_kit
   bakery:
     type: FCC
     name: Bakery
@@ -541,7 +545,9 @@ factories:
       - make_refractor
       - crack_fossil
       - upgrade_to_adv_ore_smelter
+      - make_ore_smelter_kit
       - repair_ore_smelter
+      - repair_ore_smelter_kit
   adv_ore_smelter:
     type: FCCUPGRADE
     name: Advanced Ore Smelter
@@ -562,7 +568,9 @@ factories:
       - make_refractor
       - crack_fossil
       - upgrade_to_elite_ore_smelter
+      - make_adv_ore_smelter_kit
       - repair_adv_ore_smelter
+      - repair_adv_ore_smelter_kit
   elite_ore_smelter:
     type: FCCUPGRADE
     name: Elite Ore Smelter
@@ -583,7 +591,9 @@ factories:
       - elite_smelt_deepslate_lapis_ore
       - make_refractor
       - crack_fossil
+      - make_elite_ore_smelter_kit
       - repair_elite_ore_smelter
+      - repair_elite_ore_smelter_kit
   diamond_helm:
     type: FCC
     name: Diamond Helmet Smith
@@ -1198,8 +1208,11 @@ factories:
       - make_rail
       - make_powered_rail
       - make_detector_rail
+      - make_activator_rail
       - make_minecart
+      - make_rails_kit
       - repair_rails
+      - repair_rails_kit
   husbandry:
     type: FCC
     name: Animal Husbandry
@@ -1224,7 +1237,9 @@ factories:
       - make_saddle
       - make_lead
       - make_bio_component
+      - make_husbandry_kit
       - repair_husbandry
+      - repair_husbandry_kit
   iron_forge:
     type: FCC
     name: Iron Forge
@@ -1255,7 +1270,9 @@ factories:
       - make_lantern
       - make_soul_lantern
       - make_lodestone
+      - make_forge_kit
       - repair_forge
+      - repair_forge_kit
   redstone_mechanics:
     type: FCC
     name: Redstone Mechanics Factory
@@ -1283,7 +1300,9 @@ factories:
       - make_repeater
       - make_gearbox
       - make_sculk_sensor
+      - make_redstone_kit
       - repair_redstone
+      - repair_redstone_kit
   bastion_factory:
     type: FCC
     name: Bastion Factory
@@ -1372,7 +1391,9 @@ factories:
       - crush_disc_precipice
       - crush_disc_creator
       - crush_disc_creator_music_box
+      - make_bastion_kit
       - repair_bastion
+      - repair_bastion_kit
   basic_cauldron:
     type: FCC
     name: Basic Cauldron
@@ -1407,7 +1428,9 @@ factories:
       - basic_xp_5
       - wither_skull
       - upgrade_to_advanced_cauldron
+      - make_basic_cauldron_kit
       - repair_basic_cauldron
+      - repair_basic_cauldron_kit
   advanced_cauldron:
     type: FCCUPGRADE
     name: Advanced Cauldron
@@ -1419,7 +1442,9 @@ factories:
       - adv_xp_4
       - wither_skull
       - make_energizer
+      - make_advanced_cauldron_kit
       - repair_advanced_cauldron
+      - repair_advanced_cauldron_kit
   compactor:
     type: FCC
     name: Compactor
@@ -1479,13 +1504,15 @@ factories:
       - print_book
       - print_note
       - print_secure_note
-      - repair_printer
       - craft_globe_banner_pattern
       - craft_piglin_banner_pattern
       - craft_creeper_banner_pattern
       - craft_thing_banner_pattern
       - craft_flow_banner_pattern
       - craft_guster_banner_pattern
+      - make_printer_kit
+      - repair_printer
+      - repair_printer_kit
   research_station:
     type: FCC
     name: Research Station
@@ -1539,7 +1566,9 @@ factories:
       - fabricate_spire_trim
       - fabricate_bolt_trim
       - fabricate_flow_trim
+      - make_station_kit
       - repair_station
+      - repair_station_kit
   concrete_mixer:
     type: FCC
     name: Concrete Mixer
@@ -1591,7 +1620,9 @@ factories:
       - crush_disc_ward
       - crush_disc_wait
       - crush_disc_otherside
+      - make_mixer_kit
       - repair_mixer
+      - repair_mixer_kit
   bio_factory:
     type: FCC
     name: Bio Factory
@@ -1638,7 +1669,9 @@ factories:
       - crush_disc_13
       - crush_disc_cat
       - crush_disc_blocks
+      - make_bio_kit
       - repair_bio
+      - repair_bio_kit
   gold_forge:
     type: FCC
     name: Gold Forge
@@ -1720,7 +1753,9 @@ factories:
       - weather_copper_trapdoors
       - weather_exposed_copper_trapdoors
       - weather_weathered_copper_trapdoors
+      - make_copper_workshop_kit
       - repair_copper_workshop
+      - repair_copper_workshop_kit
 #RECIPES
 recipes:
   facet_heliodor:
@@ -5981,6 +6016,49 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: BUCKET
         amount: 1
+  make_gem_kit:
+    production_time: 4s
+    name: Make Gem Factory Repair Kit
+    type: PRODUCTION
+    input:
+      gold:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GOLD_BLOCK
+        amount: 16
+      emerald:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: EMERALD_BLOCK
+        amount: 16
+      lapis:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: LAPIS_BLOCK
+        amount: 32
+      essence:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ENDER_EYE
+        amount: 8
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Player Essence
+          lore:
+            - Activity reward used to fuel pearls
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Gem Factory Repair Kit
+          lore:
+            - One kit will repair a Gem Factory to full health.        
   repair_gem_factory:
     production_time: 4s
     name: Repair Factory
@@ -6012,6 +6090,23 @@ recipes:
           display-name: Player Essence
           lore:
             - Activity reward used to fuel pearls
+    health_gained: 10000
+  repair_gem_factory_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Gem Factory Repair Kit
+          lore:
+            - One kit will repair a Gem Factory to full health.
     health_gained: 10000
   repair_stone_smelter:
     production_time: 4s
@@ -6090,6 +6185,33 @@ recipes:
         type: GLASS
         amount: 16
     health_gained: 10000
+  make_mixer_kit:
+    production_time: 4s
+    name: Make Concrete Mixer Repair Kit
+    type: PRODUCTION
+    input:
+      sand:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: SAND
+        amount: 24
+      gravel:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GRAVEL
+        amount: 24
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Concrete Mixer Repair Kit
+          lore:
+            - One kit will repair a Concrete Mixer to full health.          
   repair_mixer:
     production_time: 4s
     name: Repair Factory
@@ -6106,6 +6228,50 @@ recipes:
         type: GRAVEL
         amount: 24
     health_gained: 10000
+  repair_mixer_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Concrete Mixer Repair Kit
+          lore:
+            - One kit will repair a Concrete Mixer to full health. 
+    health_gained: 10000
+  make_grill_kit:
+    production_time: 4s
+    name: Make Grill Factory Repair Kit
+    type: PRODUCTION
+    input:
+      iron:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: IRON_INGOT
+        amount: 8
+      bricks:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BRICKS
+        amount: 8
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Grill Factory Repair Kit
+          lore:
+            - One kit will repair a Grill Factory to full health.        
   repair_grill:
     production_time: 4s
     name: Repair Factory
@@ -6122,6 +6288,23 @@ recipes:
         type: BRICKS
         amount: 8
     health_gained: 10000
+  repair_grill_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Grill Factory Repair Kit
+          lore:
+            - One kit will repair a Grill Factory to full health.
+    health_gained: 10000
   repair_bakery:
     production_time: 4s
     name: Repair Factory
@@ -6133,6 +6316,49 @@ recipes:
         type: BRICKS
         amount: 16
     health_gained: 10000
+  make_ore_smelter_kit:
+    production_time: 4s
+    name: Make Ore Smelter Repair Kit
+    type: PRODUCTION
+    input:
+      coal:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: COAL
+        amount: 48
+      iron:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: IRON_INGOT
+        amount: 24
+      diamond:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: DIAMOND
+        amount: 6
+      essence:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ENDER_EYE
+        amount: 8
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Player Essence
+          lore:
+            - Activity reward used to fuel pearls
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Ore Smelter Repair Kit
+          lore:
+            - One kit will repair a Ore Smelter to full health.        
   repair_ore_smelter:
     production_time: 4s
     name: Repair Factory
@@ -6165,6 +6391,66 @@ recipes:
           lore:
             - Activity reward used to fuel pearls
     health_gained: 10000
+  repair_ore_smelter_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Ore Smelter Repair Kit
+          lore:
+            - One kit will repair a Ore Smelter to full health.
+    health_gained: 10000
+  make_adv_ore_smelter_kit:
+    production_time: 4s
+    name: Make Advanced Ore Smelter Repair Kit
+    type: PRODUCTION
+    input:
+      diamond:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: DIAMOND
+        amount: 8
+      emerald:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: EMERALD
+        amount: 8
+      ancient_debris:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ANCIENT_DEBRIS
+        amount: 1
+      essence:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ENDER_EYE
+        amount: 4
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Player Essence
+          lore:
+            - Activity reward used to fuel pearls
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Advanced Ore Smelter Repair Kit
+          lore:
+            - One kit will repair a Advanced Ore Smelter to full health.  
   repair_adv_ore_smelter:
     production_time: 4s
     name: Repair Factory
@@ -6197,6 +6483,64 @@ recipes:
           lore:
             - Activity reward used to fuel pearls
     health_gained: 10000
+  repair_adv_ore_smelter_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Advanced Ore Smelter Repair Kit
+          lore:
+            - One kit will repair a Advanced Ore Smelter to full health.
+    health_gained: 10000
+  make_elite_ore_smelter_kit:
+    production_time: 4s
+    name: Make Elite Ore Smelter Repair Kit
+    type: PRODUCTION
+    input:
+      diamond:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: DIAMOND
+        amount: 16
+      emerald:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: EMERALD
+        amount: 16
+      meteoric_iron_ingot:
+        custom-key: meteoric_iron_ingot
+        amount: 1
+      essence:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ENDER_EYE
+        amount: 8
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Player Essence
+          lore:
+            - Activity reward used to fuel pearls
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Elite Ore Smelter Repair Kit
+          lore:
+            - One kit will repair a Elite Ore Smelter to full health.  
   repair_elite_ore_smelter:
     production_time: 4s
     name: Repair Factory
@@ -6226,6 +6570,23 @@ recipes:
           display-name: Player Essence
           lore:
             - Activity reward used to fuel pearls
+    health_gained: 10000
+  repair_elite_ore_smelter_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Elite Ore Smelter Repair Kit
+          lore:
+            - One kit will repair a Elite Ore Smelter to full health.
     health_gained: 10000
   make_fences:
     production_time: 4s
@@ -7417,6 +7778,27 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: DETECTOR_RAIL
         amount: 32
+  make_activator_rail:
+    production_time: 4s
+    name: Make Activator Rails
+    type: PRODUCTION
+    input:
+      iron:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: IRON_INGOT
+        amount: 18
+      redstone:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: REDSTONE
+        amount: 2
+    output:
+      activator_rail:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ACTIVATOR_RAIL
+        amount: 32
   make_minecart:
     production_time: 4s
     name: Make Minecarts
@@ -7433,6 +7815,33 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: MINECART
         amount: 27
+  make_rails_kit:
+    production_time: 4s
+    name: Make Rail Factory Repair Kit
+    type: PRODUCTION
+    input:
+      iron:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: IRON_INGOT
+        amount: 6
+      redstone:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: REDSTONE
+        amount: 1
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Rail Factory Repair Kit
+          lore:
+            - One kit will repair a Rail Factory to full health.          
   repair_rails:
     production_time: 4s
     name: Repair Factory
@@ -7448,6 +7857,23 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: REDSTONE
         amount: 1
+    health_gained: 10000
+  repair_rails_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Rail Factory Repair Kit
+          lore:
+            - One kit will repair a Rail Factory to full health.  
     health_gained: 10000
   make_saddle:
     production_time: 4s
@@ -7475,58 +7901,6 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: SADDLE
         amount: 8
-  make_elytra:
-    production_time: 60s
-    name: Make Elytra
-    type: PRODUCTION
-    input:
-      bamboo:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: BAMBOO
-        amount: 64
-        meta:
-          meta-type: UNSPECIFIC
-          ==: ItemMeta
-          lore:
-            - Compacted Item
-      membrane:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: PHANTOM_MEMBRANE
-        amount: 128
-      essence:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: ENDER_EYE
-        amount: 256
-        meta:
-          meta-type: UNSPECIFIC
-          ==: ItemMeta
-          display-name: Player Essence
-          lore:
-            - Activity reward used to fuel pearls
-      leather:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: LEATHER
-        amount: 64
-      emerald_block:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: EMERALD_BLOCK
-        amount: 2
-        meta:
-          meta-type: UNSPECIFIC
-          ==: ItemMeta
-          lore:
-            - Compacted Item
-    output:
-      elytra:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: ELYTRA
-        amount: 1
   make_torch:
     production_time: 4s
     name: Make Redstone Torches
@@ -7642,6 +8016,38 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: SCULK_SENSOR
         amount: 4
+  make_redstone_kit:
+    production_time: 4s
+    name: Make Redstone Factory Repair Kit
+    type: PRODUCTION
+    input:
+      iron:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: IRON_INGOT
+        amount: 6
+      redstone:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: REDSTONE
+        amount: 25
+      gold:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GOLD_INGOT
+        amount: 3
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Redstone Factory Repair Kit
+          lore:
+            - One kit will repair a Redstone Factory to full health.        
   repair_redstone:
     production_time: 4s
     name: Repair Factory
@@ -7662,6 +8068,23 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: GOLD_INGOT
         amount: 3
+    health_gained: 10000
+  repair_redstone_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Redstone Factory Repair Kit
+          lore:
+            - One kit will repair a Redstone Factory to full health.
     health_gained: 10000
   make_iron_helm:
     production_time: 4s
@@ -8223,6 +8646,100 @@ recipes:
           lore:
             - Activity reward used to fuel pearls
     health_gained: 10000
+  make_bastion_kit:
+    production_time: 4s
+    name: Make Bastion Factory Repair Kit
+    type: PRODUCTION
+    input:
+      casing:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ENDER_CHEST
+        amount: 4
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Casing
+          lore:
+            - Casing for bastion
+      gearbox:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: CLOCK
+        amount: 4
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Gearbox
+          lore:
+            - Gear mechanism for bastion
+      radar:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: COMPASS
+        amount: 3
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Radar
+          lore:
+            - Radar for detecting pearls
+      energizer:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: EMERALD
+        amount: 3
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Energizer
+          lore:
+            - Power source for bastion
+      refractor:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: DIAMOND
+        amount: 3
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Refractor
+          lore:
+            - Refractor for bastion
+      bio_component:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: MAGMA_CREAM
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Bio-Component
+          lore:
+            - Bio-Component for bastion
+      essence:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ENDER_EYE
+        amount: 16
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Player Essence
+          lore:
+            - Activity reward used to fuel pearls
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Bastion Factory Repair Kit
+          lore:
+            - One kit will repair a Bastion Factory to full health.
   repair_bastion:
     production_time: 4s
     name: Repair Factory
@@ -8305,6 +8822,23 @@ recipes:
           display-name: Player Essence
           lore:
             - Activity reward used to fuel pearls
+    health_gained: 10000
+  repair_bastion_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Bastion Factory Repair Kit
+          lore:
+            - One kit will repair a Bastion Factory to full health.
     health_gained: 10000
   make_iron_fence:
     production_time: 4s
@@ -8550,6 +9084,33 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: SHEARS
         amount: 16
+  make_forge_kit:
+    production_time: 4s
+    name: Make Iron Forge Repair Kit
+    type: PRODUCTION
+    input:
+      iron:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: IRON_INGOT
+        amount: 12
+      lava_bucket:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: LAVA_BUCKET
+        amount: 1
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Iron Forge Repair Kit
+          lore:
+            - One kit will repair a Iron Forge to full health.
   repair_forge:
     production_time: 4s
     name: Repair Factory
@@ -8565,6 +9126,23 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: LAVA_BUCKET
         amount: 1
+    health_gained: 10000
+  repair_forge_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Iron Forge Repair Kit
+          lore:
+            - One kit will repair a Iron Forge to full health.
     health_gained: 10000
   make_lead:
     production_time: 4s
@@ -8587,6 +9165,38 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: LEAD
         amount: 12
+  make_husbandry_kit:
+    production_time: 4s
+    name: Make Animal Husbandry Repair Kit
+    type: PRODUCTION
+    input:
+      iron:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: IRON_BLOCK
+        amount: 3
+      slime:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: SLIME_BALL
+        amount: 2
+      leather:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: LEATHER
+        amount: 3
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Animal Husbandry Repair Kit
+          lore:
+            - One kit will repair a Animal Husbandry to full health.
   repair_husbandry:
     production_time: 4s
     name: Repair Factory
@@ -8607,6 +9217,23 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: LEATHER
         amount: 3
+    health_gained: 10000
+  repair_husbandry_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Animal Husbandry Repair Kit
+          lore:
+            - One kit will repair a Animal Husbandry to full health.
     health_gained: 10000
   smelt_bricks:
     production_time: 4s
@@ -9213,6 +9840,44 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: NETHER_STAR
         amount: 1
+  make_basic_cauldron_kit:
+    production_time: 4s
+    name: Make Basic Cauldron Repair Kit
+    type: PRODUCTION
+    input:
+      iron:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: IRON_INGOT
+        amount: 12
+      gold:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GOLD_INGOT
+        amount: 3
+      essence:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ENDER_EYE
+        amount: 5
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Player Essence
+          lore:
+            - Activity reward used to fuel pearls
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Basic Cauldron Repair Kit
+          lore:
+            - One kit will repair a Basic Cauldron to full health.
   repair_basic_cauldron:
     production_time: 4s
     name: Repair Factory
@@ -9239,6 +9904,23 @@ recipes:
           display-name: Player Essence
           lore:
             - Activity reward used to fuel pearls
+    health_gained: 10000
+  repair_basic_cauldron_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Basic Cauldron Repair Kit
+          lore:
+            - One kit will repair a Basic Cauldron to full health.
     health_gained: 10000
   adv_xp_1:
     production_time: 4s
@@ -9855,6 +10537,39 @@ recipes:
         type: WITHER_SKELETON_SKULL
         amount: 1
     factory: Advanced Cauldron
+  make_advanced_cauldron_kit:
+    production_time: 4s
+    name: Make Advanced Cauldron Repair Kit
+    type: PRODUCTION
+    input:
+      emerald_block:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: EMERALD_BLOCK
+        amount: 16
+      essence:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ENDER_EYE
+        amount: 16
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Player Essence
+          lore:
+            - Activity reward used to fuel pearls
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Advanced Cauldron Repair Kit
+          lore:
+            - One kit will repair a Advanced Cauldron to full health.
   repair_advanced_cauldron:
     production_time: 4s
     name: Repair Factory
@@ -9876,6 +10591,23 @@ recipes:
           display-name: Player Essence
           lore:
             - Activity reward used to fuel pearls
+    health_gained: 10000
+  repair_advanced_cauldron_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Advanced Cauldron Repair Kit
+          lore:
+            - One kit will repair a Advanced Cauldron to full health.
     health_gained: 10000
   compact:
     production_time: 1s
@@ -11388,6 +12120,33 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: FLOW_BANNER_PATTERN
         amount: 1
+  make_printer_kit:
+    production_time: 4s
+    name: Make Printer Factory Repair Kit
+    type: PRODUCTION
+    input:
+      ink:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: INK_SAC
+        amount: 3
+      paper:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: PAPER
+        amount: 6
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Printer Factory Repair Kit
+          lore:
+            - One kit will repair a Printer Factory to full health.
   repair_printer:
     forceInclude: true
     type: REPAIR
@@ -11405,6 +12164,61 @@ recipes:
         type: PAPER
         amount: 6
     health_gained: 10000
+  repair_printer_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Printer Factory Repair Kit
+          lore:
+            - One kit will repair a Printer Factory to full health.
+    health_gained: 10000
+  make_station_kit:
+    production_time: 4s
+    name: Make Research Station Repair Kit
+    type: PRODUCTION
+    input:
+      essence:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ENDER_EYE
+        amount: 8
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Player Essence
+          lore:
+            - Activity reward used to fuel pearls
+      paper:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: PAPER
+        amount: 16
+      ink:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: INK_SAC
+        amount: 2
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Research Station Repair Kit
+          lore:
+            - One kit will repair a Research Station to full health.
   repair_station:
     forceInclude: true
     type: REPAIR
@@ -11433,6 +12247,23 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: INK_SAC
         amount: 2
+    health_gained: 10000
+  repair_station_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Research Station Repair Kit
+          lore:
+            - One kit will repair a Research Station to full health.
     health_gained: 10000
   wax_copper_block:
     production_time: 4s
@@ -11961,6 +12792,33 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: BUCKET
         amount: 1
+  make_copper_workshop_kit:
+    production_time: 4s
+    name: Make Copper Workshop Repair Kit
+    type: PRODUCTION
+    input:
+      copper_block:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: COPPER_BLOCK
+        amount: 64
+      honeycomb:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: HONEYCOMB
+        amount: 16
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Copper Workshop Repair Kit
+          lore:
+            - One kit will repair a Copper Workshop to full health.
   repair_copper_workshop:
     production_time: 4s
     name: Repair Factory
@@ -11970,27 +12828,29 @@ recipes:
         v: 3839
         ==: org.bukkit.inventory.ItemStack
         type: COPPER_BLOCK
-        amount: 16
-      exposed_copper:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: EXPOSED_COPPER
-        amount: 16
-      weathered_copper:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: WEATHERED_COPPER
-        amount: 16
-      oxidized_copper:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: OXIDIZED_COPPER
-        amount: 16
+        amount: 64
       honeycomb:
         v: 3839
         ==: org.bukkit.inventory.ItemStack
         type: HONEYCOMB
         amount: 16
+    health_gained: 10000
+  repair_copper_workshop_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Copper Workshop Repair Kit
+          lore:
+            - One kit will repair a Copper Workshop to full health.
     health_gained: 10000
   crack_fossil:
     type: RANDOM
@@ -12944,6 +13804,33 @@ recipes:
           ==: org.bukkit.inventory.ItemStack
           type: JUKEBOX
           amount: 1
+  make_bio_kit:
+    production_time: 4s
+    name: Make Bio Factory Repair Kit
+    type: PRODUCTION
+    input:
+      bone_block:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BONE_BLOCK
+        amount: 8
+      dirt:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: DIRT
+        amount: 16
+    output:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Bio Factory Repair Kit
+          lore:
+            - One kit will repair a Bio Factory to full health.
   repair_bio:
     production_time: 4s
     fuel_consumption_intervall: 1s
@@ -12960,6 +13847,23 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: DIRT
         amount: 16
+    health_gained: 10000
+  repair_bio_kit:
+    production_time: 4s
+    name: Repair Factory using Repair Kit
+    type: REPAIR
+    input:
+      kit:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          display-name: Bio Factory Repair Kit
+          lore:
+            - One kit will repair a Bio Factory to full health.
     health_gained: 10000
   repair_gold_forge:
     production_time: 4s

--- a/ansible/files/paper-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/paper-config/plugins/FactoryMod/config.yml
@@ -10698,7 +10698,7 @@ recipes:
           ==: ItemMeta
           display-name: Compact Repair Kit
           lore:
-            - One kit will repair a Compactor to full health.
+            - One kit will repair a compactor to full health.
     health_gained: 10000
   make_compact_repair_kit:
     production_time: 4s
@@ -10741,7 +10741,7 @@ recipes:
           ==: ItemMeta
           display-name: Compact Repair Kit
           lore:
-            - One kit will repair a Compactor to full health.
+            - One kit will repair a compactor to full health.
   make_crates:
     production_time: 4s
     name: Make Crates

--- a/ansible/files/paper-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/paper-config/plugins/FactoryMod/config.yml
@@ -346,6 +346,8 @@ factories:
       - make_prismarine_bricks
       - make_dark_prismarine
       - make_sea_lantern
+      - dye_froglight_verdant
+      - dye_froglight_ochre
       - make_end_rods
       - make_redstone_lamp
       - make_flower_pot
@@ -3237,6 +3239,48 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: SEA_LANTERN
         amount: 32
+  dye_froglight_verdant:
+    production_time: 4s
+    name: Dye Verdant Froglight
+    type: PRODUCTION
+    input:
+      pearlescent_froglight:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: PEARLESCENT_FROGLIGHT
+        amount: 16
+      lime_dye:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: LIME_DYE
+        amount: 4
+    output:
+      verdant_froglight:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: VERDANT_FROGLIGHT
+        amount: 16
+  dye_froglight_ochre:
+    production_time: 4s
+    name: Dye Ochre Froglight
+    type: PRODUCTION
+    input:
+      pearlescent_froglight:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: PEARLESCENT_FROGLIGHT
+        amount: 16
+      orange_dye:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: ORANGE_DYE
+        amount: 4
+    output:
+      Ochre_froglight:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: OCHRE_FROGLIGHT
+        amount: 16
   make_end_rods:
     production_time: 4s
     name: Make End Rods

--- a/ansible/files/paper-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/paper-config/plugins/FactoryMod/config.yml
@@ -15,7 +15,6 @@ use_recipe_yamlidentifiers: true
 log_inventories: true
 force_include_default: true
 can_upgrade: true
-
 factories:
   meteoric_iron_sword:
     type: FCC
@@ -312,6 +311,8 @@ factories:
       - charcoal_from_jungle_log
       - charcoal_from_acacia_log
       - charcoal_from_dark_oak_log
+      - charcoal_from_cherry_log
+      - charcoal_from_mangrove_log
       - charcoal_from_crimson_stem
       - charcoal_from_warped_stem
       - charcoal_from_coal
@@ -2941,6 +2942,38 @@ recipes:
         v: 3839
         ==: org.bukkit.inventory.ItemStack
         type: DARK_OAK_LOG
+        amount: 64
+    output:
+      charcoal:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: CHARCOAL
+        amount: 128
+  charcoal_from_cherry_log:
+    production_time: 4s
+    name: Make Charcoal from Cherry Logs
+    type: PRODUCTION
+    input:
+      log:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: CHERRY_LOG
+        amount: 64
+    output:
+      charcoal:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: CHARCOAL
+        amount: 128
+  charcoal_from_mangrove_log:
+    production_time: 4s
+    name: Make Charcoal from Mangrove Logs
+    type: PRODUCTION
+    input:
+      log:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: MANGROVE_LOG
         amount: 64
     output:
       charcoal:
@@ -6043,7 +6076,7 @@ recipes:
           ==: ItemMeta
           display-name: Gem Factory Repair Kit
           lore:
-            - One kit will repair a Gem Factory to full health.        
+            - One kit will repair a Gem Factory to full health.
   repair_gem_factory:
     production_time: 4s
     name: Repair Factory
@@ -6196,7 +6229,7 @@ recipes:
           ==: ItemMeta
           display-name: Concrete Mixer Repair Kit
           lore:
-            - One kit will repair a Concrete Mixer to full health.          
+            - One kit will repair a Concrete Mixer to full health.
   repair_mixer:
     production_time: 4s
     name: Repair Factory
@@ -6228,7 +6261,7 @@ recipes:
           ==: ItemMeta
           display-name: Concrete Mixer Repair Kit
           lore:
-            - One kit will repair a Concrete Mixer to full health. 
+            - One kit will repair a Concrete Mixer to full health.
     health_gained: 10000
   make_grill_kit:
     production_time: 4s
@@ -6256,7 +6289,7 @@ recipes:
           ==: ItemMeta
           display-name: Grill Factory Repair Kit
           lore:
-            - One kit will repair a Grill Factory to full health.        
+            - One kit will repair a Grill Factory to full health.
   repair_grill:
     production_time: 4s
     name: Repair Factory
@@ -6343,7 +6376,7 @@ recipes:
           ==: ItemMeta
           display-name: Ore Smelter Repair Kit
           lore:
-            - One kit will repair a Ore Smelter to full health.        
+            - One kit will repair an Ore Smelter to full health.
   repair_ore_smelter:
     production_time: 4s
     name: Repair Factory
@@ -6391,7 +6424,7 @@ recipes:
           ==: ItemMeta
           display-name: Ore Smelter Repair Kit
           lore:
-            - One kit will repair a Ore Smelter to full health.
+            - One kit will repair an Ore Smelter to full health.
     health_gained: 10000
   make_adv_ore_smelter_kit:
     production_time: 4s
@@ -6435,7 +6468,7 @@ recipes:
           ==: ItemMeta
           display-name: Advanced Ore Smelter Repair Kit
           lore:
-            - One kit will repair a Advanced Ore Smelter to full health.  
+            - One kit will repair an Advanced Ore Smelter to full health.
   repair_adv_ore_smelter:
     production_time: 4s
     name: Repair Factory
@@ -6483,7 +6516,7 @@ recipes:
           ==: ItemMeta
           display-name: Advanced Ore Smelter Repair Kit
           lore:
-            - One kit will repair a Advanced Ore Smelter to full health.
+            - One kit will repair an Advanced Ore Smelter to full health.
     health_gained: 10000
   make_elite_ore_smelter_kit:
     production_time: 4s
@@ -6525,7 +6558,7 @@ recipes:
           ==: ItemMeta
           display-name: Elite Ore Smelter Repair Kit
           lore:
-            - One kit will repair a Elite Ore Smelter to full health.  
+            - One kit will repair an Elite Ore Smelter to full health.
   repair_elite_ore_smelter:
     production_time: 4s
     name: Repair Factory
@@ -6571,7 +6604,7 @@ recipes:
           ==: ItemMeta
           display-name: Elite Ore Smelter Repair Kit
           lore:
-            - One kit will repair a Elite Ore Smelter to full health.
+            - One kit will repair an Elite Ore Smelter to full health.
     health_gained: 10000
   make_fences:
     production_time: 4s
@@ -7826,7 +7859,7 @@ recipes:
           ==: ItemMeta
           display-name: Rail Factory Repair Kit
           lore:
-            - One kit will repair a Rail Factory to full health.          
+            - One kit will repair a Rail Factory to full health.
   repair_rails:
     production_time: 4s
     name: Repair Factory
@@ -7858,7 +7891,7 @@ recipes:
           ==: ItemMeta
           display-name: Rail Factory Repair Kit
           lore:
-            - One kit will repair a Rail Factory to full health.  
+            - One kit will repair a Rail Factory to full health.
     health_gained: 10000
   make_saddle:
     production_time: 4s
@@ -8032,7 +8065,7 @@ recipes:
           ==: ItemMeta
           display-name: Redstone Factory Repair Kit
           lore:
-            - One kit will repair a Redstone Factory to full health.        
+            - One kit will repair a Redstone Factory to full health.
   repair_redstone:
     production_time: 4s
     name: Repair Factory
@@ -9095,7 +9128,7 @@ recipes:
           ==: ItemMeta
           display-name: Iron Forge Repair Kit
           lore:
-            - One kit will repair a Iron Forge to full health.
+            - One kit will repair an Iron Forge to full health.
   repair_forge:
     production_time: 4s
     name: Repair Factory
@@ -9127,7 +9160,7 @@ recipes:
           ==: ItemMeta
           display-name: Iron Forge Repair Kit
           lore:
-            - One kit will repair a Iron Forge to full health.
+            - One kit will repair an Iron Forge to full health.
     health_gained: 10000
   make_lead:
     production_time: 4s
@@ -9181,7 +9214,7 @@ recipes:
           ==: ItemMeta
           display-name: Animal Husbandry Repair Kit
           lore:
-            - One kit will repair a Animal Husbandry to full health.
+            - One kit will repair an Animal Husbandry to full health.
   repair_husbandry:
     production_time: 4s
     name: Repair Factory
@@ -9218,7 +9251,7 @@ recipes:
           ==: ItemMeta
           display-name: Animal Husbandry Repair Kit
           lore:
-            - One kit will repair a Animal Husbandry to full health.
+            - One kit will repair an Animal Husbandry to full health.
     health_gained: 10000
   smelt_bricks:
     production_time: 4s
@@ -10665,7 +10698,7 @@ recipes:
           ==: ItemMeta
           display-name: Compact Repair Kit
           lore:
-            - One kit will repair a compactor to full health.
+            - One kit will repair a Compactor to full health.
     health_gained: 10000
   make_compact_repair_kit:
     production_time: 4s
@@ -10708,7 +10741,7 @@ recipes:
           ==: ItemMeta
           display-name: Compact Repair Kit
           lore:
-            - One kit will repair a compactor to full health.
+            - One kit will repair a Compactor to full health.
   make_crates:
     production_time: 4s
     name: Make Crates
@@ -11890,7 +11923,6 @@ recipes:
           ==: org.bukkit.inventory.ItemStack
           type: EMERALD
           amount: 1
-
   print_note:
     type: PRINTNOTE
     name: Print Note


### PR DESCRIPTION
Adds repair kits for: 
* gem factory
* grill
* ore smelter
* adv ore smelter
* elite ore smelter
* rail
* husbandry
* forge
* redstone
* bastion
* basic cauldron
* advanced cauldron
* printer
* research
* concrete
* bio
* copper

- Adds a recipe in rail factory to make Activator rails.
costing 18 iron and 2 redstone to produce 32 activator rails. Same as the detector recipe.
- Adds recipes for mangrove/cherry wood to charcoal in the charcoal factory
- Adds recipes to dye froglights to the verdant and ochre versions in the aesthetics factory. 

I simplified the copper workshop repair recipe, needing 16 of every oxidation level seemed just an annoyance. Made it 64 normal copper blocks instead.

Also removes the Elytra recipe because it wasn't being used in a factory anyways. 

Resolves #711, resolves #710, Resolves #695