### PR TITLE
Update backup-and-restart.sh

### DIFF
--- a/ansible/templates/backup-and-restart.sh
+++ b/ansible/templates/backup-and-restart.sh
@@ -17,9 +17,7 @@ restic \
   /opt/stacks/minecraft/ \
   --exclude '**orebfuscator_cache'\
   --exclude '**civmodcore_cache'\
-  --exclude '**dynmap'\
   --exclude '**postgres-data'\
-  --exclude '**plugins'
 
 echo "$(date) Starting services after backup..."
 docker service scale minecraft_paper=1


### PR DESCRIPTION
Dynmap doesn't exist and Plugins contains import information like the factorymod files. The plugins folder will add a negligible amount of data to the backups.