### PR TITLE
Reattempt ModSupport hack

### DIFF
--- a/ansible/files/paper-config/plugins/SimpleAdminHacks/config.yml
+++ b/ansible/files/paper-config/plugins/SimpleAdminHacks/config.yml
@@ -503,6 +503,8 @@ hacks:
     send-world-info: true
     # Whether to send contextual inventory information
     send-inventory-location: true
+    # Whether to notify the player whether their fishing rod has caught something
+    send-nibble: false
   NewfriendAssist:
     enabled: true
     announce: '&f%Player% is brand new!'

--- a/ansible/files/paper-config/plugins/SimpleAdminHacks/config.yml
+++ b/ansible/files/paper-config/plugins/SimpleAdminHacks/config.yml
@@ -492,6 +492,17 @@ hacks:
         - "        &5Goodluck!&r\nThere are many things to do on CivMC. Let your ambitions run wild!\n\nLeave something behind people will remember for years to come.\n\nBe it your actions, your creations or your destruction..."
   InvControl:
     enabled: true
+  ModSupport:
+    enabled: true
+    send-server-tags: true
+    # Tags are bits of information the server wants the client to know. These could be anything. For example, the server
+    # could send a "no-elevation" tag to tell client mods to disable any elevation data. Or just a "CivMC" tag, letting
+    # the client figure out what that means. Or neither. It's entirely optional.
+    server-tags: ["CivMC"]
+    # Whether to send world name and uuid
+    send-world-info: true
+    # Whether to send contextual inventory information
+    send-inventory-location: true
   NewfriendAssist:
     enabled: true
     announce: '&f%Player% is brand new!'

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/bytes/ByteHelpers.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/bytes/ByteHelpers.java
@@ -1,0 +1,51 @@
+package vg.civcraft.mc.civmodcore.bytes;
+
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.BiConsumer;
+import org.jetbrains.annotations.NotNull;
+
+public final class ByteHelpers {
+    public static @NotNull ByteArrayDataOutput newPacketWriter(
+        final int initialCapacity
+    ) {
+        return ByteStreams.newDataOutput(initialCapacity);
+    }
+
+    public static <T> void writeArray(
+        final @NotNull ByteArrayDataOutput out,
+        final T @NotNull [] array,
+        final @NotNull Length lengthPrefix,
+        final @NotNull BiConsumer<@NotNull ByteArrayDataOutput, T> elementWriter
+    ) {
+        final int length = lengthPrefix.assertValidLength("array.length", array.length);
+        switch (lengthPrefix) {
+            case u8 -> out.writeByte(length);
+            case u16 -> out.writeShort(length);
+            case u31 -> out.writeInt(length);
+        }
+        for (final T element : array) {
+            elementWriter.accept(out, element);
+        }
+    }
+
+    public static <T> void writeCollection(
+        final @NotNull ByteArrayDataOutput out,
+        @NotNull Collection<T> collection,
+        final @NotNull Length lengthPrefix,
+        final @NotNull BiConsumer<@NotNull ByteArrayDataOutput, T> elementWriter
+    ) {
+        collection = new ArrayList<>(collection); // Just in case
+        final int length = lengthPrefix.assertValidLength("collection.size()", collection.size());
+        switch (lengthPrefix) {
+            case u8 -> out.writeByte(length);
+            case u16 -> out.writeShort(length);
+            case u31 -> out.writeInt(length);
+        }
+        for (final T element : collection) {
+            elementWriter.accept(out, element);
+        }
+    }
+}

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/bytes/ByteHelpers.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/bytes/ByteHelpers.java
@@ -14,6 +14,18 @@ public final class ByteHelpers {
         return ByteStreams.newDataOutput(initialCapacity);
     }
 
+    public static void writeLength(
+        final @NotNull ByteArrayDataOutput out,
+        final @NotNull Length type,
+        final int length
+    ) {
+        switch (type) {
+            case u8 -> out.writeByte(length & (int) type.max);
+            case u16 -> out.writeShort(length & (int) type.max);
+            case u31 -> out.writeInt(length & (int) type.max);
+        }
+    }
+
     public static <T> void writeArray(
         final @NotNull ByteArrayDataOutput out,
         final T @NotNull [] array,
@@ -21,11 +33,7 @@ public final class ByteHelpers {
         final @NotNull BiConsumer<@NotNull ByteArrayDataOutput, T> elementWriter
     ) {
         final int length = lengthPrefix.assertValidLength("array.length", array.length);
-        switch (lengthPrefix) {
-            case u8 -> out.writeByte(length);
-            case u16 -> out.writeShort(length);
-            case u31 -> out.writeInt(length);
-        }
+        writeLength(out, lengthPrefix, length);
         for (final T element : array) {
             elementWriter.accept(out, element);
         }
@@ -39,11 +47,7 @@ public final class ByteHelpers {
     ) {
         collection = new ArrayList<>(collection); // Just in case
         final int length = lengthPrefix.assertValidLength("collection.size()", collection.size());
-        switch (lengthPrefix) {
-            case u8 -> out.writeByte(length);
-            case u16 -> out.writeShort(length);
-            case u31 -> out.writeInt(length);
-        }
+        writeLength(out, lengthPrefix, length);
         for (final T element : collection) {
             elementWriter.accept(out, element);
         }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/bytes/Length.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/bytes/Length.java
@@ -1,0 +1,34 @@
+package vg.civcraft.mc.civmodcore.bytes;
+
+import org.jetbrains.annotations.NotNull;
+
+public enum Length {
+    u8(Byte.SIZE, Byte.BYTES, (1 << Byte.SIZE) - 1),
+    u16(Short.SIZE, Short.BYTES, (1 << Short.SIZE) - 1),
+    u31(Integer.SIZE, Integer.BYTES, Integer.MAX_VALUE),
+    ;
+
+    public final int bitLength;
+    public final int byteLength;
+    public final long max;
+
+    Length(
+        final int bitLength,
+        final int byteLength,
+        final long max
+    ) {
+        this.bitLength = bitLength;
+        this.byteLength = byteLength;
+        this.max = max;
+    }
+
+    public int assertValidLength(
+        final @NotNull String name,
+        final long length
+    ) {
+        if (length > this.max) {
+            throw new IllegalArgumentException("'" + name + "' cannot have be >" + this.max + "! [" + length + "]");
+        }
+        return (int) length;
+    }
+}

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
@@ -18,6 +18,9 @@ public final class ModSupportConfig extends SimpleHackConfig {
     // Inventories
     public boolean sendInventoryLocation;
 
+    // Botting
+    public boolean sendNibble;
+
     public ModSupportConfig(
         final @NotNull SimpleAdminHacks plugin,
         final @NotNull ConfigurationSection config
@@ -40,5 +43,8 @@ public final class ModSupportConfig extends SimpleHackConfig {
 
         // Inventory
         this.sendInventoryLocation = config.getBoolean("send-inventory-location", true);
+
+        // Botting
+        this.sendNibble = config.getBoolean("send-nibble", true);
     }
 }

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
@@ -5,6 +5,7 @@ import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHackConfig;
 import java.util.List;
 import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
+import vg.civcraft.mc.civmodcore.bytes.Length;
 
 public final class ModSupportConfig extends SimpleHackConfig {
     // Server info
@@ -31,7 +32,7 @@ public final class ModSupportConfig extends SimpleHackConfig {
         // Server info
         this.sendServerTags = config.getBoolean("send-server-tags", true);
         this.serverTags = config.getList("server-tags", null) instanceof final List<?> tags
-            ? tags.stream().limit(255).map(String::valueOf).toList()
+            ? tags.stream().limit(Length.u8.max).map(String::valueOf).toList()
             : List.of();
 
         // World info

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
@@ -2,10 +2,15 @@ package com.programmerdan.minecraft.simpleadminhacks.configs;
 
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHackConfig;
+import java.util.List;
 import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
 
 public final class ModSupportConfig extends SimpleHackConfig {
+    // Server info
+    public boolean sendServerTags;
+    public @NotNull List<@NotNull String> serverTags = List.of();
+
     public ModSupportConfig(
         final @NotNull SimpleAdminHacks plugin,
         final @NotNull ConfigurationSection config
@@ -17,6 +22,10 @@ public final class ModSupportConfig extends SimpleHackConfig {
     protected void wireup(
         final @NotNull ConfigurationSection config
     ) {
-
+        // Server info
+        this.sendServerTags = config.getBoolean("send-server-tags", true);
+        this.serverTags = config.getList("server-tags", null) instanceof final List<?> tags
+            ? tags.stream().limit(255).map(String::valueOf).toList()
+            : List.of();
     }
 }

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
@@ -1,0 +1,22 @@
+package com.programmerdan.minecraft.simpleadminhacks.configs;
+
+import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
+import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHackConfig;
+import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.NotNull;
+
+public final class ModSupportConfig extends SimpleHackConfig {
+    public ModSupportConfig(
+        final @NotNull SimpleAdminHacks plugin,
+        final @NotNull ConfigurationSection config
+    ) {
+        super(plugin, config);
+    }
+
+    @Override
+    protected void wireup(
+        final @NotNull ConfigurationSection config
+    ) {
+
+    }
+}

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
@@ -14,6 +14,9 @@ public final class ModSupportConfig extends SimpleHackConfig {
     // World info
     public boolean sendWorldInfo;
 
+    // Inventories
+    public boolean sendInventoryLocation;
+
     public ModSupportConfig(
         final @NotNull SimpleAdminHacks plugin,
         final @NotNull ConfigurationSection config
@@ -33,5 +36,8 @@ public final class ModSupportConfig extends SimpleHackConfig {
 
         // World info
         this.sendWorldInfo = config.getBoolean("send-world-info", true);
+
+        // Inventory
+        this.sendInventoryLocation = config.getBoolean("send-inventory-location", true);
     }
 }

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/ModSupportConfig.java
@@ -11,6 +11,9 @@ public final class ModSupportConfig extends SimpleHackConfig {
     public boolean sendServerTags;
     public @NotNull List<@NotNull String> serverTags = List.of();
 
+    // World info
+    public boolean sendWorldInfo;
+
     public ModSupportConfig(
         final @NotNull SimpleAdminHacks plugin,
         final @NotNull ConfigurationSection config
@@ -27,5 +30,8 @@ public final class ModSupportConfig extends SimpleHackConfig {
         this.serverTags = config.getList("server-tags", null) instanceof final List<?> tags
             ? tags.stream().limit(255).map(String::valueOf).toList()
             : List.of();
+
+        // World info
+        this.sendWorldInfo = config.getBoolean("send-world-info", true);
     }
 }

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/ModSupport.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/ModSupport.java
@@ -17,6 +17,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
@@ -178,5 +179,31 @@ public final class ModSupport extends SimpleHack<ModSupportConfig> implements Li
             default -> out.writeByte(0); // Not supported
         }
         viewer.sendPluginMessage(plugin(), MOD_SUPPORT_CHANNEL, out.toByteArray());
+    }
+
+    // ============================================================
+    // Send Nibble
+    //
+    // Sends a notification when a player has caught something on their fishing rod.
+    // ============================================================
+
+    @EventHandler(
+        ignoreCancelled = true,
+        priority = EventPriority.MONITOR
+    )
+    private void sendNibble(
+        final @NotNull PlayerFishEvent event
+    ) {
+        final PluginMessageRecipient recipient = event.getPlayer();
+        if (!this.config.sendNibble) {
+            return;
+        }
+        if (event.getState() != PlayerFishEvent.State.BITE) {
+            return;
+        }
+        final ByteArrayDataOutput out = ByteHelpers.newPacketWriter(32);
+        out.writeUTF("NIBBLE");
+        out.writeByte(1); // Packet schema id
+        recipient.sendPluginMessage(plugin(), MOD_SUPPORT_CHANNEL, out.toByteArray());
     }
 }

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/ModSupport.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/ModSupport.java
@@ -1,10 +1,12 @@
 package com.programmerdan.minecraft.simpleadminhacks.hacks;
 
+import com.destroystokyo.paper.event.player.PlayerPostRespawnEvent;
 import com.google.common.io.ByteArrayDataOutput;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.configs.ModSupportConfig;
 import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHack;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -70,5 +72,56 @@ public final class ModSupport extends SimpleHack<ModSupportConfig> implements Li
             ByteHelpers.writeCollection(out, this.config.serverTags, Length.u8, ByteArrayDataOutput::writeUTF);
             recipient.sendPluginMessage(plugin(), MOD_SUPPORT_CHANNEL, out.toByteArray());
         }
+    }
+
+    // ============================================================
+    // Send World Info
+    //
+    // Sends the world name and uuid to the client. This will allow mods to better discriminate between worlds without
+    // using dimension IDs, which may not be unique to each world.
+    // ============================================================
+
+    @EventHandler(
+        ignoreCancelled = true,
+        priority = EventPriority.MONITOR
+    )
+    private void sendWorldInfoOnLogin(
+        final @NotNull PlayerJoinEvent event
+    ) {
+        if (this.config.sendWorldInfo) {
+            INTERNAL_sendWorldInfo(
+                event.getPlayer(),
+                event.getPlayer().getWorld()
+            );
+        }
+    }
+
+    @EventHandler(
+        ignoreCancelled = true,
+        priority = EventPriority.MONITOR
+    )
+    private void sendWorldInfoOnRespawn(
+        final @NotNull PlayerPostRespawnEvent event
+    ) {
+        if (this.config.sendWorldInfo) {
+            INTERNAL_sendWorldInfo(
+                event.getPlayer(),
+                event.getRespawnedLocation().getWorld()
+            );
+        }
+    }
+
+    private void INTERNAL_sendWorldInfo(
+        final @NotNull PluginMessageRecipient recipient,
+        final @NotNull World world
+    ) {
+        final ByteArrayDataOutput out = ByteHelpers.newPacketWriter(128);
+        out.writeUTF("WORLD_INFO");
+        out.writeByte(1); // Packet schema id
+
+        out.writeUTF(world.getName());
+        out.writeUTF(world.getUID().toString());
+
+        recipient.sendPluginMessage(plugin(), MOD_SUPPORT_CHANNEL, out.toByteArray());
     }
 }

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/ModSupport.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/ModSupport.java
@@ -1,13 +1,20 @@
 package com.programmerdan.minecraft.simpleadminhacks.hacks;
 
+import com.google.common.io.ByteArrayDataOutput;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.configs.ModSupportConfig;
 import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHack;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.messaging.PluginMessageRecipient;
 import org.jetbrains.annotations.NotNull;
+import vg.civcraft.mc.civmodcore.bytes.ByteHelpers;
+import vg.civcraft.mc.civmodcore.bytes.Length;
 
 public final class ModSupport extends SimpleHack<ModSupportConfig> implements Listener {
     private static final String MOD_SUPPORT_CHANNEL = "sah:mod_support";
@@ -38,5 +45,30 @@ public final class ModSupport extends SimpleHack<ModSupportConfig> implements Li
         super.onDisable();
         HandlerList.unregisterAll(this);
         Bukkit.getMessenger().unregisterOutgoingPluginChannel(this.plugin, MOD_SUPPORT_CHANNEL);
+    }
+
+    // ============================================================
+    // Send Tags
+    //
+    // These are bits of information that the server wants the client to know. These could be anything. For example,
+    // servers could send a "no-elevation" tag to tell client mods to disable any elevation data. Or just a "CivMC" tag,
+    // letting the client figure out what that means. Or neither. It's entirely optional.
+    // ============================================================
+
+    @EventHandler(
+        ignoreCancelled = true,
+        priority = EventPriority.LOWEST
+    )
+    private void sendTagsOnJoin(
+        final @NotNull PlayerJoinEvent event
+    ) {
+        final PluginMessageRecipient recipient = event.getPlayer();
+        if (this.config.sendServerTags) {
+            final ByteArrayDataOutput out = ByteHelpers.newPacketWriter(128);
+            out.writeUTF("TAGS");
+            out.writeByte(1); // Packet schema id
+            ByteHelpers.writeCollection(out, this.config.serverTags, Length.u8, ByteArrayDataOutput::writeUTF);
+            recipient.sendPluginMessage(plugin(), MOD_SUPPORT_CHANNEL, out.toByteArray());
+        }
     }
 }

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/ModSupport.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/ModSupport.java
@@ -1,0 +1,42 @@
+package com.programmerdan.minecraft.simpleadminhacks.hacks;
+
+import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
+import com.programmerdan.minecraft.simpleadminhacks.configs.ModSupportConfig;
+import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHack;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+
+public final class ModSupport extends SimpleHack<ModSupportConfig> implements Listener {
+    private static final String MOD_SUPPORT_CHANNEL = "sah:mod_support";
+
+    public ModSupport(
+        final @NotNull SimpleAdminHacks plugin,
+        final @NotNull ModSupportConfig config
+    ) {
+        super(plugin, config);
+    }
+
+    public static @NotNull ModSupportConfig generate(
+        final @NotNull SimpleAdminHacks plugin,
+        final @NotNull ConfigurationSection config
+    ) {
+        return new ModSupportConfig(plugin, config);
+    }
+
+    @Override
+    public void onEnable() {
+        Bukkit.getMessenger().registerOutgoingPluginChannel(this.plugin, MOD_SUPPORT_CHANNEL);
+        this.plugin.registerListener(this);
+        super.onEnable();
+    }
+
+    @Override
+    public void onDisable() {
+        super.onDisable();
+        HandlerList.unregisterAll(this);
+        Bukkit.getMessenger().unregisterOutgoingPluginChannel(this.plugin, MOD_SUPPORT_CHANNEL);
+    }
+}

--- a/plugins/simpleadminhacks-paper/src/main/resources/config.yml
+++ b/plugins/simpleadminhacks-paper/src/main/resources/config.yml
@@ -453,6 +453,8 @@ hacks:
     send-world-info: true
     # Whether to send contextual inventory information
     send-inventory-location: true
+    # Whether to notify the player whether their fishing rod has caught something
+    send-nibble: true
   NewfriendAssist:
     enabled: true
     announce: '&f%Player% is brand new!'

--- a/plugins/simpleadminhacks-paper/src/main/resources/config.yml
+++ b/plugins/simpleadminhacks-paper/src/main/resources/config.yml
@@ -444,6 +444,11 @@ hacks:
     enabled: true
   ModSupport:
     enabled: true
+    send-server-tags: true
+    # Tags are bits of information the server wants the client to know. These could be anything. For example, the server
+    # could send a "no-elevation" tag to tell client mods to disable any elevation data. Or just a "CivMC" tag, letting
+    # the client figure out what that means. Or neither. It's entirely optional.
+    server-tags: ["CivMC"]
   NewfriendAssist:
     enabled: true
     announce: '&f%Player% is brand new!'

--- a/plugins/simpleadminhacks-paper/src/main/resources/config.yml
+++ b/plugins/simpleadminhacks-paper/src/main/resources/config.yml
@@ -442,6 +442,8 @@ hacks:
         - "We extend our appreciation to the devs, admins, and players at: &oreddit.com/r/Civcraft"
   InvControl:
     enabled: true
+  ModSupport:
+    enabled: true
   NewfriendAssist:
     enabled: true
     announce: '&f%Player% is brand new!'

--- a/plugins/simpleadminhacks-paper/src/main/resources/config.yml
+++ b/plugins/simpleadminhacks-paper/src/main/resources/config.yml
@@ -449,6 +449,8 @@ hacks:
     # could send a "no-elevation" tag to tell client mods to disable any elevation data. Or just a "CivMC" tag, letting
     # the client figure out what that means. Or neither. It's entirely optional.
     server-tags: ["CivMC"]
+    # Whether to send world name and uuid
+    send-world-info: true
   NewfriendAssist:
     enabled: true
     announce: '&f%Player% is brand new!'

--- a/plugins/simpleadminhacks-paper/src/main/resources/config.yml
+++ b/plugins/simpleadminhacks-paper/src/main/resources/config.yml
@@ -451,6 +451,8 @@ hacks:
     server-tags: ["CivMC"]
     # Whether to send world name and uuid
     send-world-info: true
+    # Whether to send contextual inventory information
+    send-inventory-location: true
   NewfriendAssist:
     enabled: true
     announce: '&f%Player% is brand new!'


### PR DESCRIPTION
This is a reattempt of #582 that's better written and with more features. As mentioned in the previous PR, this leverages plugin messages to send additional information that the Minecraft protocol lacks. This should help with civ-mods and mods updated to work with civ.