### PR TITLE
Allow adding blocks to safebreak

### DIFF
--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/players/settings/impl/collection/AbstractCollectionSetting.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/players/settings/impl/collection/AbstractCollectionSetting.java
@@ -29,7 +29,7 @@ public abstract class AbstractCollectionSetting<C extends Collection<T>, T> exte
     private static final String ESCAPE_REPLACE = ESCAPE_STRING + ESCAPE_STRING;
     private static final String SEPARATOR_REPLACE = ESCAPE_STRING + SEPARATOR_STRING;
 
-    private PlayerSetting<T> elementSetting;
+    protected PlayerSetting<T> elementSetting;
     private Function<C, C> newFunction;
 
     public AbstractCollectionSetting(JavaPlugin owningPlugin, C defaultValue, String name, String identifier,

--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/SafeOreBreak.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/SafeOreBreak.java
@@ -5,31 +5,37 @@ import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
 import com.programmerdan.minecraft.simpleadminhacks.framework.autoload.AutoLoad;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import java.util.UUID;
+import java.util.Set;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.apache.commons.lang.WordUtils;
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
-import vg.civcraft.mc.civmodcore.inventory.items.MaterialUtils;
+import org.jetbrains.annotations.NotNull;
+import vg.civcraft.mc.civmodcore.chat.dialog.Dialog;
+import vg.civcraft.mc.civmodcore.inventory.gui.Clickable;
+import vg.civcraft.mc.civmodcore.inventory.gui.IClickable;
+import vg.civcraft.mc.civmodcore.inventory.gui.MultiPageView;
+import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.players.settings.PlayerSettingAPI;
 import vg.civcraft.mc.civmodcore.players.settings.gui.MenuSection;
-import vg.civcraft.mc.civmodcore.players.settings.impl.BooleanSetting;
+import vg.civcraft.mc.civmodcore.players.settings.impl.collection.SetSetting;
 
 public final class SafeOreBreak extends BasicHack {
 
-    @AutoLoad
-    private List<List<String>> ores;
+    @AutoLoad(id = "ores")
+    private List<List<String>> defaultOres;
 
-    private final List<BooleanOreSetting> oreSettings = new ArrayList<>();
-    private final List<List<Material>> breakOres = new ArrayList<>();
+    private BooleanSetOreSetting setSetting;
 
     public SafeOreBreak(final SimpleAdminHacks plugin, final BasicHackConfig config) {
         super(plugin, config);
@@ -40,31 +46,29 @@ public final class SafeOreBreak extends BasicHack {
         super.onEnable();
 
         MenuSection mainMenu = plugin.getSettingManager().getMainMenu();
-
+        Set<String> settings = new HashSet<>();
         OUTER:
-        for (List<String> parts : ores) {
+        for (List<String> parts : defaultOres) {
             List<Material> materialParts = new ArrayList<>(parts.size());
 
             for (String part : parts) {
-                Material material = MaterialUtils.getMaterial(part);
+                Material material = Material.matchMaterial(part);
                 if (material == null) {
                     logger.warning("Invalid material '" + part + "'. Skipping.");
                     continue OUTER;
                 }
                 materialParts.add(material);
             }
-
-            breakOres.add(materialParts);
-            String materialName = PlainTextComponentSerializer.plainText().serialize(Component.translatable(materialParts.get(0)));
-            BooleanOreSetting setting = new BooleanOreSetting(plugin, false,
-                "Safe " + materialName + " break",
-                "safeOreBreak_" + materialParts.get(0).getKey().getKey(),
-                "Prevents you from breaking " + materialName
-                    + " without a silk touch pickaxe.",
-                materialParts.get(0));
-            oreSettings.add(setting);
-            PlayerSettingAPI.registerSetting(setting, mainMenu);
+            settings.add(getNiceMatName(materialParts.getFirst()));
         }
+        PlayerSettingAPI.registerSetting(setSetting = new BooleanSetOreSetting(
+            plugin,
+            settings,
+            "Safe break",
+            "safeBreak",
+            new ItemStack(Material.BARREL),
+            "Prevents you from breaking blocks without a silk touch tool"
+        ), mainMenu);
     }
 
     @Override
@@ -74,7 +78,8 @@ public final class SafeOreBreak extends BasicHack {
 
     @EventHandler(ignoreCancelled = true)
     public void onOreBreak(BlockBreakEvent event) {
-        if (event.getPlayer().getGameMode() != GameMode.SURVIVAL) {
+        Player player = event.getPlayer();
+        if (player.getGameMode() != GameMode.SURVIVAL) {
             return;
         }
 
@@ -83,50 +88,97 @@ public final class SafeOreBreak extends BasicHack {
             return;
         }
 
-        OUTER:
-        for (int i = 0; i < breakOres.size(); i++) {
-            List<Material> list = breakOres.get(i);
-            for (Material material : list) {
-                if (material == event.getBlock().getType()) {
-                    Boolean value = oreSettings.get(i).getValue(event.getPlayer());
+        if (setSetting.getValue(player).contains(getNiceMatName(event.getBlock().getType()))) {
+            event.getPlayer().sendMessage(
+                Component.text("A SimpleAdminHacks /config option is preventing you from breaking " +
+                    event.getBlock().getType().getKey().getKey()
+                    + " without a silk touch tool.", NamedTextColor.RED)
+            );
 
-                    if (!value) {
-                        continue OUTER;
-                    }
-
-                    event.getPlayer().sendMessage(Component.text(
-                            "A SimpleAdminHacks /config option is preventing you from breaking that ore without a silk touch pickaxe.")
-                        .color(NamedTextColor.RED));
-
-                    event.setCancelled(true);
-                    return;
-                }
-            }
+            event.setCancelled(true);
         }
     }
 
-    private static class BooleanOreSetting extends BooleanSetting {
+    private static class BooleanSetOreSetting extends SetSetting<String> {
 
-        private final Material ore;
-
-        public BooleanOreSetting(JavaPlugin owningPlugin, Boolean defaultValue, String name, String identifier,
-                                 String description, Material ore) {
-            super(owningPlugin, defaultValue, name, identifier, description);
-            this.ore = ore;
+        public BooleanSetOreSetting(JavaPlugin owningPlugin, Set<String> defaultValue, String name, String identifier,
+                                    ItemStack gui, String description) {
+            super(owningPlugin, defaultValue, name, identifier, gui, description, String.class);
         }
 
         @Override
-        public ItemStack getGuiRepresentation(UUID player) {
-            ItemStack item;
-            if (getValue(player)) {
-                item = new ItemStack(ore);
-                item.addUnsafeEnchantment(Enchantment.UNBREAKING, 1);
-                item.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-            } else {
-                item = new ItemStack(ore);
-            }
-            applyInfoToItemStack(item, player);
-            return item;
+        public boolean isValidValue(String input) {
+            Material material = Material.matchMaterial(input);
+            return material != null && material.isBlock();
         }
+
+        @Override
+        public void handleMenuClick(Player player, MenuSection menu) {
+            Set<String> value = getValue(player);
+            List<IClickable> clickables = new ArrayList<>(value.size());
+            for (String element : value) {
+                elementSetting.setValue(player, element);
+                Material material = Material.matchMaterial(element);
+                ItemStack is;
+                if (material == null || material.asItemType() == null) {
+                    is = new ItemStack(Material.BARRIER);
+                } else {
+                    is = new ItemStack(material);
+                }
+                ItemUtils.setComponentDisplayName(is, Component.text(elementSetting.toText(element), NamedTextColor.GOLD));
+                clickables.add(new Clickable(is) {
+
+                    @Override
+                    public void clicked(Player p) {
+                        removeElement(player.getUniqueId(), element);
+                        player.sendMessage(Component.text(String.format("Removed %s from %s", elementSetting.toText(element), getNiceName()), NamedTextColor.GREEN));
+                        handleMenuClick(player, menu);
+                    }
+                });
+            }
+            MultiPageView pageView = new MultiPageView(player, clickables, getNiceName(), true);
+            ItemStack parentItem = new ItemStack(Material.ARROW);
+            ItemUtils.setComponentDisplayName(parentItem, Component.text("Go back to " + menu.getName(), NamedTextColor.AQUA));
+            pageView.setMenuSlot(new Clickable(parentItem) {
+
+                @Override
+                public void clicked(@NotNull Player p) {
+                    menu.showScreen(p);
+                }
+            }, 0);
+            ItemStack addItemStack = new ItemStack(Material.GREEN_CONCRETE);
+            ItemUtils.setComponentDisplayName(addItemStack, Component.text("Add new entry", NamedTextColor.GOLD));
+            pageView.setMenuSlot(new Clickable(addItemStack) {
+
+                @Override
+                public void clicked(@NotNull Player p) {
+                    new Dialog(p, getOwningPlugin(), ChatColor.GOLD + "Enter the name of the entry to add") {
+
+                        @Override
+                        public List<String> onTabComplete(String wordCompleted, String[] fullMessage) {
+                            return null;
+                        }
+
+                        @Override
+                        public void onReply(String[] message) {
+                            String full = String.join(" ", message);
+                            Material material = Material.matchMaterial(full);
+                            if (material == null || !material.isBlock() || material.asItemType() == null) {
+                                p.sendMessage(Component.text("You entered an invalid value", NamedTextColor.RED));
+                            } else {
+                                p.sendMessage(Component.text("Added " + material.getKey().getKey().replace('_', ' '), NamedTextColor.GREEN));
+                                addElement(p.getUniqueId(), elementSetting.deserialize(getNiceMatName(material)));
+                            }
+                            handleMenuClick(player, menu);
+                        }
+                    };
+                }
+            }, 3);
+            pageView.showScreen();
+        }
+    }
+
+    private static String getNiceMatName(Material material) {
+        return WordUtils.capitalizeFully(material.getKey().getKey().replace('_', ' '));
     }
 }


### PR DESCRIPTION
Allows players to add whatever blocks they want to safebreak. Keeps support for the default blocks in the config.