### PR TITLE
Date parity between pearls and /ep showall

### DIFF
--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
@@ -43,7 +43,7 @@ final class CoreLoreGenerator implements LoreProvider {
         Preconditions.checkNotNull(config, "config");
 
         this.config = config;
-        this.dateFormat = new SimpleDateFormat("MM/dd/yyyy");
+        this.dateFormat = new SimpleDateFormat("dd MMM yyyy");
         this.exilePearlid = exilePearLid;
     }
 


### PR DESCRIPTION
This updates the pearl-lore generator to use the same date formatter as `/ep showall`.

Here's what the date looks like on the pearl:
![image](https://github.com/user-attachments/assets/8f038b08-3be1-4fd0-92b2-4fdb32a1d5eb)

Which is confusing to non-Americans, compared to what is shown on `/ep showall`:
![image](https://github.com/user-attachments/assets/901bb406-62eb-43de-ba24-6cbadab11770)