### PR TITLE
Reattempt KeyedUtils pruning

### DIFF
--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/EnchantUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/EnchantUtils.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.translation.Translatable;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
@@ -20,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
-import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 
 /**
  * Class of static utilities for Enchantments.
@@ -117,7 +117,7 @@ public final class EnchantUtils {
         }
         Enchantment enchantment;
         // From NamespacedKey
-        final var enchantmentKey = KeyedUtils.fromString(value);
+        final NamespacedKey enchantmentKey = NamespacedKey.fromString(value);
         if (enchantmentKey != null) {
             enchantment = Enchantment.getByKey(enchantmentKey);
             if (enchantment != null) {

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MoreTags.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/items/MoreTags.java
@@ -14,6 +14,7 @@ import org.bukkit.Tag;
 import org.bukkit.block.data.Ageable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import vg.civcraft.mc.civmodcore.CivModCorePlugin;
 import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 
@@ -293,7 +294,7 @@ public final class MoreTags {
         private final Set<T> values;
 
         private BetterTag(final String key, final Set<T> values) {
-            this.key = KeyedUtils.fromParts("civmodcore", key);
+            this.key = KeyedUtils.pluginKey(CivModCorePlugin.class, key);
             this.values = values;
         }
 

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/KeyedUtils.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/KeyedUtils.java
@@ -1,7 +1,9 @@
 package vg.civcraft.mc.civmodcore.utilities;
 
-import org.bukkit.Keyed;
+import net.kyori.adventure.key.Keyed;
 import org.bukkit.NamespacedKey;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -9,65 +11,75 @@ import org.jetbrains.annotations.Nullable;
  * Utility class to make dealing with namespace keys easier.
  */
 public final class KeyedUtils {
-
     /**
-     * Converts a stringified namespaced-key back into a {@link NamespacedKey}.
+     * Convenience shortcut for constructing a key namespaced to a plugin.
      *
-     * @param key The stringified namespace-key, which MUST be formatted as {@code namespace:name}
-     * @return Returns a valid {@link NamespacedKey}, or null.
-     * @throws IllegalArgumentException Will throw if the stringified key fails a "[a-z0-9._-]+" check, or if the
-     *                                  total length is longer than 256.
+     * <pre><code>
+     * // If you used NamespacedKey as intended
+     * new NamespacedKey(ExamplePlugin.getInstance(), "example");
+     *
+     * // Using KeyedUtils.pluginKey()
+     * KeyedUtils.pluginKey(ExamplePlugin.class, "example");
+     * </code></pre>
      */
-    @Nullable
-    public static NamespacedKey fromString(@Nullable final String key) {
-        return key == null ? null : NamespacedKey.fromString(key);
+    public static <T extends JavaPlugin> @NotNull NamespacedKey pluginKey(
+        final @NotNull Class<T> pluginClass,
+        final @NotNull String key
+    ) {
+        return new NamespacedKey(JavaPlugin.getPlugin(pluginClass), key);
     }
 
     /**
-     * Converts a namespace and a key into a {@link NamespacedKey}.
+     * Retrieves a {@link net.kyori.adventure.key.Keyed}'s {@link net.kyori.adventure.key.Key} and converts it to a
+     * string.
      *
-     * @param namespace The namespace name.
-     * @param key       The namespaced key.
-     * @return Returns a valid {@link NamespacedKey}, or null.
-     * @throws IllegalArgumentException Will throw if either part fails a "[a-z0-9._-]+" check, or if the total
-     *                                  combined length is longer than 256.
+     * @return Returns the stringified key, or null if the given keyed was null.
      */
-    @SuppressWarnings("deprecation")
-    @NotNull
-    public static NamespacedKey fromParts(@NotNull final String namespace, @NotNull final String key) {
-        return new NamespacedKey(namespace, key);
+    @Contract("!null -> !null")
+    public static @Nullable String getString(
+        final Keyed keyed
+    ) {
+        return keyed == null ? null : keyed.key().asString();
     }
 
     /**
-     * Converts a {@link NamespacedKey} into a string.
-     *
-     * @param key The {@link NamespacedKey} to convert.
-     * @return Returns the stringified {@link NamespacedKey}, or null.
+     * Creates a new {@link NamespacedKey} for testing purposes.
      */
-    @Nullable
-    public static String getString(@Nullable final NamespacedKey key) {
-        return key == null ? null : key.toString();
-    }
-
-    /**
-     * Retrieves a {@link Keyed}'s {@link NamespacedKey} and converts it to a string.
-     *
-     * @param keyed The {@link Keyed} instance.
-     * @return Returns the stringified {@link Keyed}'s {@link NamespacedKey}, or null.
-     */
-    @Nullable
-    public static String getString(@Nullable final Keyed keyed) {
-        return keyed == null ? null : getString(keyed.getKey());
-    }
-
-    /**
-     * @param key The namespaced-key.
-     * @return Returns a new {@link NamespacedKey} for testing purposes.
-     */
-    @SuppressWarnings("deprecation")
-    @NotNull
-    public static NamespacedKey testKey(@NotNull final String key) {
+    public static @NotNull NamespacedKey testKey(
+        final @NotNull String key
+    ) {
         return new NamespacedKey("test", key);
     }
 
+    /**
+     * Creates a <a href="https://dictionary.cambridge.org/dictionary/english/ditto">ditto</a> key, primarily for child
+     * keys within {@link org.bukkit.persistence.PersistentDataContainer PersistentDataContainers}.
+     *
+     * <pre><code>
+     * // If you used PDCs as intended
+     * {
+     *     "CivModCore:players": [
+     *         {
+     *             "CivModCore:name": "Example",
+     *             "CivModCore:uuid": "61629d9c-c2a1-4379-b98e-4b538c6628c5"
+     *         }
+     *     ]
+     * }
+     *
+     * // Using ditto keys
+     * {
+     *     "CivModCore:players": [
+     *         {
+     *             "_:name": "Example",
+     *             "_:uuid": "61629d9c-c2a1-4379-b98e-4b538c6628c5"
+     *         }
+     *     ]
+     * }
+     * </code></pre>
+     */
+    public static @NotNull NamespacedKey dittoKey(
+        final @NotNull String key
+    ) {
+        return new NamespacedKey("_", key);
+    }
 }

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantModifier.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/modifiers/EnchantModifier.java
@@ -92,7 +92,6 @@ public final class EnchantModifier extends ModifierData {
         nbt.setCompound(REQUIRED_KEY, NBTEncodings.encodeLeveledEnchants(getRequiredEnchants()));
         nbt.setStringArray(EXCLUDED_KEY, getExcludedEnchants().stream()
             .map(KeyedUtils::getString)
-            .filter(Objects::nonNull)
             .toArray(String[]::new));
         nbt.setBoolean(UNLISTED_KEY, isAllowingUnlistedEnchants());
     }

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/Utilities.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/Utilities.java
@@ -176,7 +176,7 @@ public final class Utilities {
         }
         return "[" +
             leveledEnchants.entrySet().stream()
-                .map(entry -> KeyedUtils.getString(entry.getKey()) + ":" + entry.getValue())
+                .map((entry) -> KeyedUtils.getString(entry.getKey()) + ":" + entry.getValue())
                 .collect(Collectors.joining(",")) +
             "]";
     }
@@ -187,7 +187,7 @@ public final class Utilities {
         }
         return "[" +
             enchants.stream()
-                .map(entry -> KeyedUtils.getString(entry.getKey()))
+                .map(KeyedUtils::getString)
                 .collect(Collectors.joining(",")) +
             "]";
     }


### PR DESCRIPTION
This is a reattempt of #400, which prunes various parts of `KeyedUtils`, particularly the `fromParts()` method since the relevant `NamespacedKey` constructor [was de-deprecated](https://github.com/PaperMC/Paper/issues/7753). `KeyedUtils` now fulfils its intention of filling in the gaps of keys, rather than attempting to provide pseudo null safety.