### PR TITLE
Improve banstick's proxy ip collection

### DIFF
--- a/ansible/files/paper-config/plugins/BanStick/config.yml
+++ b/ansible/files/paper-config/plugins/BanStick/config.yml
@@ -102,6 +102,18 @@ proxy:
     url: https://raw.githubusercontent.com/growlfm/ipcat/refs/heads/main/datacenters.csv
     period: 576000
     delay: 4200
+  proxylist:
+    enable: true
+    defaultScore: 3.0
+    ban:
+      length: 86400000
+      message: VPS / VPN Proxy use is generally prohibited. Modmail to www.reddit.com/r/CivMC to discuss
+    urls:
+      - https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/socks5.txt
+      - https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/socks4.txt
+      - https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/http.txt
+    period: 576000
+    delay: 4200
 # Configure the tor check source; set autoban to true to not only track tor usage but also pre-set bans for tor users
 tor:
   check: true

--- a/ansible/files/paper-config/plugins/BanStick/config.yml
+++ b/ansible/files/paper-config/plugins/BanStick/config.yml
@@ -99,7 +99,7 @@ proxy:
     ban:
       length: 163800000
       message: 'VPS / VPN Proxy use is generally prohibited. Issue a ticket at support in the CivMC Discord to discuss: https://discord.gg/nDnsU6vJqg'
-    url: https://raw.githubusercontent.com/client9/ipcat/master/datacenters.csv
+    url: https://raw.githubusercontent.com/growlfm/ipcat/refs/heads/main/datacenters.csv
     period: 576000
     delay: 4200
 # Configure the tor check source; set autoban to true to not only track tor usage but also pre-set bans for tor users

--- a/ansible/files/pvp-config/plugins/BanStick/config.yml
+++ b/ansible/files/pvp-config/plugins/BanStick/config.yml
@@ -102,6 +102,18 @@ proxy:
     url: https://raw.githubusercontent.com/growlfm/ipcat/refs/heads/main/datacenters.csv
     period: 576000
     delay: 4200
+  proxylist:
+    enable: true
+    defaultScore: 3.0
+    ban:
+      length: 86400000
+      message: VPS / VPN Proxy use is generally prohibited. Modmail to www.reddit.com/r/CivMC to discuss
+    urls:
+      - https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/socks5.txt
+      - https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/socks4.txt
+      - https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/http.txt
+    period: 576000
+    delay: 4200
 # Configure the tor check source; set autoban to true to not only track tor usage but also pre-set bans for tor users
 tor:
   check: true

--- a/ansible/files/pvp-config/plugins/BanStick/config.yml
+++ b/ansible/files/pvp-config/plugins/BanStick/config.yml
@@ -99,7 +99,7 @@ proxy:
     ban:
       length: 163800000
       message: 'VPS / VPN Proxy use is generally prohibited. Issue a ticket at support in the CivMC Discord to discuss: https://discord.gg/nDnsU6vJqg'
-    url: https://raw.githubusercontent.com/client9/ipcat/master/datacenters.csv
+    url: https://raw.githubusercontent.com/growlfm/ipcat/refs/heads/main/datacenters.csv
     period: 576000
     delay: 4200
 # Configure the tor check source; set autoban to true to not only track tor usage but also pre-set bans for tor users

--- a/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/data/BSIPData.java
+++ b/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/data/BSIPData.java
@@ -302,7 +302,8 @@ public final class BSIPData {
                     allIPDataID.put(data.idid, data);
                     return data;
                 } else {
-                    BanStick.getPlugin().warning("Failed to retrieve IP Data by exact IP: {0} - not found", ip);
+                    // No reason to log here, just spams console, especially on import
+                    // BanStick.getPlugin().warning("Failed to retrieve IP Data by exact IP: {0} - not found", ip);
                 }
             }
         } catch (SQLException se) {

--- a/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/proxy/PROXYListLoader.java
+++ b/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/proxy/PROXYListLoader.java
@@ -1,0 +1,137 @@
+package com.programmerdan.minecraft.banstick.proxy;
+
+import com.programmerdan.minecraft.banstick.BanStick;
+import com.programmerdan.minecraft.banstick.data.BSBan;
+import com.programmerdan.minecraft.banstick.data.BSIP;
+import com.programmerdan.minecraft.banstick.data.BSIPData;
+import com.programmerdan.minecraft.banstick.handler.ProxyLoader;
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
+import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.NotNull;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URL;
+import java.util.*;
+
+public final class PROXYListLoader extends ProxyLoader {
+
+    private @NotNull List<String> urls;
+    private float proxyScore;
+    private boolean autoBan;
+    private long banLength;
+    private String banMessage;
+
+    public PROXYListLoader(ConfigurationSection config) {
+        super(config);
+    }
+
+    @Override
+    public void run() {
+        BanStick.getPlugin().info("Running proxylist loader: {0}", name());
+        for (String url : this.urls) {
+            try {
+                URL connection = new URI(url).toURL();
+                InputStream readIn = connection.openStream();
+                BufferedReader in = new BufferedReader(new InputStreamReader(readIn));
+                String line = in.readLine();
+                int errors = 0;
+                long lines = 0;
+                while (line != null) {
+                    lines++;
+                    if (lines % 50 == 0) {
+                        BanStick.getPlugin().info("Checked {0} entries from proxylist so far", lines);
+                    }
+                    if (errors > 10) {
+                        break;
+                    }
+
+                    String[] parts = line.split(":");
+                    if (parts.length != 2) {
+                        errors++;
+                        continue;
+                    }
+                    String ip = parts[0];
+                    IPAddressString ipAddressString = new IPAddressString(ip);
+                    ipAddressString.validate();
+                    IPAddress ipAddress = ipAddressString.toAddress();
+
+                    BSIP found = BSIP.byIPAddress(ipAddress);
+                    if (found == null) {
+                        found = BSIP.create(ipAddress);
+                    }
+
+                    BSIPData data = BSIPData.byExactIP(found);
+                    if (data == null) {
+                        data = BSIPData.create(found, null, null, null, null, null, null, null,
+                            null, null, null, null, proxyScore, "proxylist Proxy Loader", null);
+                    }
+
+                    if (autoBan) {
+                        boolean wasmatch = false;
+
+                        List<BSBan> ban = BSBan.byProxy(data, true);
+                        if (!(ban == null || ban.isEmpty())) {
+                            // look for match; if unexpired, extend.
+                            for (int i = ban.size() - 1; i >= 0; i--) {
+                                BSBan pickOne = ban.get(i);
+                                if (pickOne.isAdminBan()) {
+                                    continue; // skip admin entered bans.
+                                }
+                                if (pickOne.getBanEndTime() != null && pickOne.getBanEndTime().after(new Date())) {
+                                    if (this.banLength < 0) { // endless
+                                        pickOne.clearBanEndTime();
+                                    } else {
+                                        pickOne.setBanEndTime(new Date(System.currentTimeMillis()
+                                            + this.banLength));
+                                    }
+                                    wasmatch = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (!wasmatch) {
+                            BSBan.create(data, this.banMessage,
+                                this.banLength < 0 ? null : new Date(System.currentTimeMillis()
+                                    + this.banLength), false);
+                        }
+                    }
+
+                    line = in.readLine();
+                }
+                if (errors > 10) {
+                    BanStick.getPlugin().warning("Cancelled proxylist load due to too many errors.");
+                }
+                BanStick.getPlugin().info("Finished loading {0} entries from proxylist: {1}", lines, url);
+            } catch (Exception e) {
+                BanStick.getPlugin().warning("Failed reading from proxylist: " + url);
+                BanStick.getPlugin().warning("  Failure message: ", e);
+            }
+        }
+    }
+
+    @Override
+    public void setup(ConfigurationSection config) {
+        this.proxyScore = (float) config.getDouble("defaultScore", 3.0d);
+        this.autoBan = config.isConfigurationSection("ban");
+        if (this.autoBan) {
+            this.banLength = config.getLong("ban.length", -1L);
+            this.banMessage = config.getString("ban.message", null);
+        }
+
+        if (config.isList("urls")) {
+            this.urls = config.getStringList("urls");
+            BanStick.getPlugin().info("Loaded {0} proxylist URLs", this.urls.size());
+        } else {
+            this.urls = new ArrayList<>();
+            BanStick.getPlugin().warning("No proxylist URLs configured, loader will not run.");
+        }
+    }
+
+    @Override
+    public String name() {
+        return "proxylist";
+    }
+}

--- a/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/proxy/PROXYListLoader.java
+++ b/plugins/banstick-paper/src/main/java/com/programmerdan/minecraft/banstick/proxy/PROXYListLoader.java
@@ -30,9 +30,10 @@ public final class PROXYListLoader extends ProxyLoader {
 
     @Override
     public void run() {
-        BanStick.getPlugin().info("Running proxylist loader: {0}", name());
         for (String url : this.urls) {
             try {
+                BanStick.getPlugin().debug("Scraping {0}", url);
+
                 URL connection = new URI(url).toURL();
                 InputStream readIn = connection.openStream();
                 BufferedReader in = new BufferedReader(new InputStreamReader(readIn));
@@ -54,6 +55,7 @@ public final class PROXYListLoader extends ProxyLoader {
                         continue;
                     }
                     String ip = parts[0];
+                    String port = parts[1];
                     IPAddressString ipAddressString = new IPAddressString(ip);
                     ipAddressString.validate();
                     IPAddress ipAddress = ipAddressString.toAddress();
@@ -66,7 +68,7 @@ public final class PROXYListLoader extends ProxyLoader {
                     BSIPData data = BSIPData.byExactIP(found);
                     if (data == null) {
                         data = BSIPData.create(found, null, null, null, null, null, null, null,
-                            null, null, null, null, proxyScore, "proxylist Proxy Loader", null);
+                            null, null, null, null, proxyScore, "proxylist Proxy Loader", "Anon Proxy on Port: " + port);
                     }
 
                     if (autoBan) {

--- a/plugins/banstick-paper/src/main/resources/config.yml
+++ b/plugins/banstick-paper/src/main/resources/config.yml
@@ -97,7 +97,7 @@ proxy:
     ban:
       length: 163800000
       message: VPS / VPN Proxy use is generally prohibited. Modmail to www.reddit.com/r/Devoted to discuss
-    url: https://raw.githubusercontent.com/client9/ipcat/master/datacenters.csv
+    url: https://raw.githubusercontent.com/growlfm/ipcat/refs/heads/main/datacenters.csv
     period: 576000
     delay: 4200
 # Configure the tor check source; set autoban to true to not only track tor usage but also pre-set bans for tor users

--- a/plugins/banstick-paper/src/main/resources/config.yml
+++ b/plugins/banstick-paper/src/main/resources/config.yml
@@ -100,6 +100,19 @@ proxy:
     url: https://raw.githubusercontent.com/growlfm/ipcat/refs/heads/main/datacenters.csv
     period: 576000
     delay: 4200
+  proxylist:
+    enable: true
+    defaultScore: 3.0
+    ban:
+      length: 86400000
+      message: VPS / VPN Proxy use is generally prohibited. Modmail to www.reddit.com/r/CivMC to discuss
+    urls:
+      - https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/socks5.txt
+      - https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/socks4.txt
+      - https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/http.txt
+    period: 576000
+    delay: 4200
+
 # Configure the tor check source; set autoban to true to not only track tor usage but also pre-set bans for tor users
 tor:
   check: true


### PR DESCRIPTION
Changes:
- Switched from client9's 6 year old datacenter list, to growlfm's maintained list
- Added another source of public proxy ips (PROXY-List)
- Fixed scraping of Free Proxy List's site

If I were in charge, I'd also switch on iphub, as that's disabled for some reason

Forgot to mentioned but the pvp server and main server interfere with each other's ratelimits. I'd fix it, but that could be (sorta) temporarily solved with adjusting the config values, or with a rearchitecting (which would probably never be merged).