### PR TITLE
set java timezone to UTC

### DIFF
--- a/ansible/templates/stacks/minecraft.yml.j2
+++ b/ansible/templates/stacks/minecraft.yml.j2
@@ -35,6 +35,8 @@ services:
             CIV_TIMEOUT_TIME: 30000
             CIV_PVP_HOSTNAME: '{{setting.minecraft.pvp_hostname}}'
             CIV_HOSTNAME: '{{setting.minecraft.hostname}}'
+
+            TZ: "UTC"
         deploy:
             placement:
                 constraints: [node.role == manager]
@@ -107,6 +109,7 @@ services:
             CIV_FORWARDING_SECRET: '{{secret.minecraft.forwarding_secret}}'
 
             JVM_OPTS: -agentpath:./libti.so -XX:+UseGraalJIT -Djdk.graal.CompilerConfiguration=enterprise -Djdk.graal.TuneInlinerExploration=1
+            TZ: "UTC"
         volumes:
             # Persistence
             - /opt/stacks/minecraft/paper-data:/data
@@ -201,6 +204,8 @@ services:
 
             CIV_WATCHDOG_TIMEOUT_TIME: 60
             CIV_FORWARDING_SECRET: '{{secret.minecraft.forwarding_secret}}'
+
+            TZ: "UTC"
 
         volumes:
             # Persistence

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       CIV_HOSTNAME: 'main.localhost'
 
       CIV_FORWARDING_SECRET: '1234'
+
+      TZ: "UTC"
     ports:
       - "25565:25577"
     volumes:
@@ -91,6 +93,8 @@ services:
       JVM_OPTS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
       CIV_WATCHDOG_TIMEOUT_TIME: 6000
       CIV_FORWARDING_SECRET: '1234'
+
+      TZ: "UTC"
     ports:
       - "5005:5005"
     volumes:
@@ -146,6 +150,8 @@ services:
       JVM_OPTS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006
       CIV_WATCHDOG_TIMEOUT_TIME: 6000
       CIV_FORWARDING_SECRET: '1234'
+
+      TZ: "UTC"
     ports:
       - "5006:5006"
     volumes:


### PR DESCRIPTION
Slightly different then #774, this forces the entire JVM into using UTC instead of just setting the timezone for dates in exilepearl. This ensures everything uses UTC, instead of just assuming it does, like everyone thought was the case for exilepearl.