### PR TITLE
add more pumpkin and melon vanilla soils to realisticbiomes

### DIFF
--- a/plugins/realisticbiomes-paper/src/main/java/com/untamedears/realisticbiomes/growth/FruitGrower.java
+++ b/plugins/realisticbiomes-paper/src/main/java/com/untamedears/realisticbiomes/growth/FruitGrower.java
@@ -13,7 +13,7 @@ import vg.civcraft.mc.civmodcore.world.WorldUtils;
 
 public class FruitGrower extends IArtificialGrower {
 
-    private List<Material> validSoil = Arrays.asList(Material.DIRT, Material.GRASS_BLOCK, Material.FARMLAND);
+    private List<Material> validSoil = Arrays.asList(Material.DIRT, Material.GRASS_BLOCK, Material.FARMLAND, Material.MOSS_BLOCK, Material.COARSE_DIRT, Material.PODZOL, Material.PALE_MOSS_BLOCK);
     private Material attachedStem;
     private Material nonAttachedStem;
     private Material fruitMaterial;

--- a/plugins/realisticbiomes2-paper/src/main/java/com/untamedears/realisticbiomes/growth/FruitGrower.java
+++ b/plugins/realisticbiomes2-paper/src/main/java/com/untamedears/realisticbiomes/growth/FruitGrower.java
@@ -13,7 +13,7 @@ import vg.civcraft.mc.civmodcore.world.WorldUtils;
 
 public class FruitGrower extends IArtificialGrower {
 
-    private List<Material> validSoil = Arrays.asList(Material.DIRT, Material.GRASS_BLOCK, Material.FARMLAND);
+    private List<Material> validSoil = Arrays.asList(Material.DIRT, Material.GRASS_BLOCK, Material.FARMLAND, Material.MOSS_BLOCK, Material.COARSE_DIRT, Material.PODZOL, Material.PALE_MOSS_BLOCK);
     private Material attachedStem;
     private Material nonAttachedStem;
     private Material fruitMaterial;


### PR DESCRIPTION
To provide more parity with vanilla (and less disappointment to farm designers), this PR would add Moss Blocks, Pale Moss Blocks, Coarse Dirt, and Podzol as valid soils for pumpkins and melons on both CivMC and CivMini.

For reference, I've linked here the Minecraft Wiki pages+sections for blocks these two crops will grow on:
https://minecraft.wiki/w/Melon#Farming
https://minecraft.wiki/w/Pumpkin#Farming

I decided to omit mycelium, mud, and rooted soil variants to keep the number of checks from being too high, and also due to them being less likely to be used in farms (unlike podzol and coarse dirt, which would be a very common scenario for newfriends farming Pumpkins in taiga biomes). Under this logic, it's debatable whether pale moss blocks should be included, but I decided to due to its presence in Mini's worldgen.