### PR TITLE
fix labeling of 'random output' factory recipes

### DIFF
--- a/ansible/files/paper-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/paper-config/plugins/FactoryMod/config.yml
@@ -11770,6 +11770,12 @@ recipes:
           lore:
             - Crack it open for a surprise!
     outputs:
+      display:
+        display:
+          v: 3839
+          ==: org.bukkit.inventory.ItemStack
+          type: EGG
+          amount: 1
       #Food--- 60%
       egg:
         chance: 0.15
@@ -12973,6 +12979,12 @@ recipes:
           lore:
             - Crack me in a factory for a prize!
     outputs:
+      display:
+        display:
+          v: 3839
+          ==: org.bukkit.inventory.ItemStack
+          type: PRISMARINE_SHARD
+          amount: 1
       # Trash - 70% of total (0.175 each)
       cobblestone:
         chance: 0.175

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/RandomOutputRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/RandomOutputRecipe.java
@@ -21,6 +21,7 @@ public class RandomOutputRecipe extends InputRecipe {
     private Map<ItemMap, Double> outputs;
     private static Random rng;
     private ItemMap lowestChanceMap;
+    private ItemMap displayOutput;
 
     public RandomOutputRecipe(String identifier, String name, int productionTime, ItemMap input,
                               Map<ItemMap, Double> outputs, ItemMap displayOutput) {
@@ -42,8 +43,10 @@ public class RandomOutputRecipe extends InputRecipe {
             if (lowestChanceMap == null) {
                 lowestChanceMap = new ItemMap(new ItemStack(Material.STONE));
             }
+            this.displayOutput = lowestChanceMap;
         } else {
             lowestChanceMap = displayOutput;
+            this.displayOutput = displayOutput;
         }
     }
 
@@ -96,7 +99,7 @@ public class RandomOutputRecipe extends InputRecipe {
 
     @Override
     public Material getRecipeRepresentationMaterial() {
-        return input.getItemStackRepresentation().get(0).getType();
+        return displayOutput.getItemStackRepresentation().get(0).getType();
     }
 
     @Override


### PR DESCRIPTION
This fixes gold factory recipes to display the items they output from their recipes (e.g. Forge Gold Pick displays a gold pick icon), while retaining the prismarine label for fossil cracking, etc.

I did *not* change this for mini as that server does not load in my dev environment, and I was not able to test it as a result.