### PR TITLE
fix player name spacing

### DIFF
--- a/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/CivChat2Manager.java
+++ b/plugins/civchat2-paper/src/main/java/vg/civcraft/mc/civchat2/CivChat2Manager.java
@@ -524,7 +524,7 @@ public class CivChat2Manager {
 
             Component compMessage = Component.text("[", NamedTextColor.GRAY)
                 .append(Component.text(group.getName(), color))
-                .append(Component.text("]", NamedTextColor.GRAY))
+                .append(Component.text("] ", NamedTextColor.GRAY))
                 .append(senderName)
                 .append(Component.text(": ", NamedTextColor.GRAY))
                 .append(Component.empty().color(NamedTextColor.WHITE).append(message));


### PR DESCRIPTION
Before (live):
<img width="360" height="24" alt="image" src="https://github.com/user-attachments/assets/556f1be0-f52e-4552-ad95-248f7abd26a8" />

After (fixed):
<img width="363" height="23" alt="image" src="https://github.com/user-attachments/assets/ce0b6b43-0e90-4f1e-846a-078bb1a5e679" />
