### PR TITLE
Fix error when enchants.yml missing

### DIFF
--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/CivModCorePlugin.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/CivModCorePlugin.java
@@ -43,8 +43,6 @@ public class CivModCorePlugin extends ACivMod {
     public void onEnable() {
         instance = this;
         registerConfigClass(DatabaseCredentials.class);
-        // Save default resources
-        saveDefaultResource("enchants.yml");
         super.onEnable();
         // Load Config
         this.config = new CivModCoreConfig(this);


### PR DESCRIPTION
Defunct file. This will just error when the file isn't present.