### PR TITLE
Truncate Factory Recipes in GUI

### DIFF
--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/FactoryModGUI.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/FactoryModGUI.java
@@ -101,13 +101,7 @@ public class FactoryModGUI {
             lore.add(ChatColor.DARK_AQUA + "Fuel: " + ChatColor.GRAY + ItemUtils.getItemName(fccEgg.getFuel().getType()));
             lore.add("");
             lore.add(ChatColor.GOLD + String.valueOf(fccEgg.getRecipes().size() + " recipes:"));
-            for (IRecipe rec : fccEgg.getRecipes()) {
-                if (rec instanceof Upgraderecipe) {
-                    lore.add(ChatColor.GRAY + " - " + ChatColor.GREEN + rec.getName());
-                } else {
-                    lore.add(ChatColor.GRAY + " - " + ChatColor.AQUA + rec.getName());
-                }
-            }
+            lore.addAll(buildTruncatedList(fccEgg.getRecipes(), 15));
             ItemUtils.addLore(is, lore);
             clicks.add(new LClickable(is, p -> {
                 showForFactory(fccEgg);
@@ -368,6 +362,35 @@ public class FactoryModGUI {
 
     private FurnCraftChestEgg getParent(FurnCraftChestEgg factory) {
         return upgradeMapping.get(factory);
+    }
+
+    private List<String> buildTruncatedList(List<IRecipe> input, int maxSize) {
+        int totalElements = input.size();
+        List<String> loreList = new ArrayList<>();
+
+        if (totalElements <= maxSize) {
+            for (IRecipe item : input) {
+                if (item instanceof Upgraderecipe) {
+                    loreList.add(ChatColor.GRAY + " - " + ChatColor.GREEN + item.getName());
+                } else {
+                    loreList.add(ChatColor.GRAY + " - " + ChatColor.AQUA + item.getName());
+                }
+            }
+        } else {
+            List<IRecipe> subListForDisplay = input.subList(0, maxSize);
+
+            for (IRecipe item : subListForDisplay) {
+                if (item instanceof Upgraderecipe) {
+                    loreList.add(ChatColor.GRAY + " - " + ChatColor.GREEN + item.getName());
+                } else {
+                    loreList.add(ChatColor.GRAY + " - " + ChatColor.AQUA + item.getName());
+                }
+            }
+
+            int remainingCount = totalElements - maxSize;
+            loreList.add(ChatColor.GRAY + "... click for " + remainingCount + " other recipes");
+        }
+        return loreList;
     }
 
     private abstract class FMCHistoryItem implements HistoryItem {

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/FactoryModGUI.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/FactoryModGUI.java
@@ -367,26 +367,25 @@ public class FactoryModGUI {
     private List<String> buildTruncatedList(List<IRecipe> input, int maxSize) {
         int totalElements = input.size();
         List<String> loreList = new ArrayList<>();
+        List<IRecipe> toDisplayList;
+        boolean truncated = false;
 
         if (totalElements <= maxSize) {
-            for (IRecipe item : input) {
-                if (item instanceof Upgraderecipe) {
-                    loreList.add(ChatColor.GRAY + " - " + ChatColor.GREEN + item.getName());
-                } else {
-                    loreList.add(ChatColor.GRAY + " - " + ChatColor.AQUA + item.getName());
-                }
-            }
+            toDisplayList = input;
         } else {
-            List<IRecipe> subListForDisplay = input.subList(0, maxSize);
+            toDisplayList = input.subList(0, maxSize);
+            truncated = true;
+        }
 
-            for (IRecipe item : subListForDisplay) {
-                if (item instanceof Upgraderecipe) {
-                    loreList.add(ChatColor.GRAY + " - " + ChatColor.GREEN + item.getName());
-                } else {
-                    loreList.add(ChatColor.GRAY + " - " + ChatColor.AQUA + item.getName());
-                }
+        for (IRecipe item : toDisplayList) {
+            if (item instanceof Upgraderecipe) {
+                loreList.add(ChatColor.GRAY + " - " + ChatColor.GREEN + item.getName());
+            } else {
+                loreList.add(ChatColor.GRAY + " - " + ChatColor.AQUA + item.getName());
             }
+        }
 
+        if (truncated) {
             int remainingCount = totalElements - maxSize;
             loreList.add(ChatColor.GRAY + "... click for " + remainingCount + " other recipes");
         }


### PR DESCRIPTION
Added Diet-Cola's patch to truncate fm's gui so it doesnt go off the screen.
<img width="312" height="459" alt="image" src="https://github.com/user-attachments/assets/ebfae0c2-c535-4c25-a25e-ddfadaec7966" />
