### PR TITLE
Fix change colour text being italicized

### DIFF
--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/gui/AdminFunctionsGUI.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/gui/AdminFunctionsGUI.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -20,7 +21,6 @@ import vg.civcraft.mc.civmodcore.chat.dialog.DialogManager;
 import vg.civcraft.mc.civmodcore.inventory.gui.Clickable;
 import vg.civcraft.mc.civmodcore.inventory.gui.ClickableInventory;
 import vg.civcraft.mc.civmodcore.inventory.gui.DecorationStack;
-import vg.civcraft.mc.civmodcore.inventory.gui.IClickable;
 import vg.civcraft.mc.civmodcore.inventory.gui.LClickable;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.namelayer.NameLayerAPI;
@@ -75,12 +75,18 @@ public class AdminFunctionsGUI extends AbstractGroupGUI {
 //        ci.setSlot(mergeClick, 12);
         ItemStack colorChangeStack = new ItemStack(Material.WHITE_DYE);
         ItemUtils.setComponentDisplayName(colorChangeStack,
-            Component.text("Change group color of ", NamedTextColor.GOLD).append(g.getGroupNameColored()));
+            Component.text("Change group color of ", NamedTextColor.GOLD)
+                .append(g.getGroupNameColored())
+                .decoration(TextDecoration.ITALIC, false)
+        );
         Clickable colorChangeClick;
         if (gm.hasAccess(g, p.getUniqueId(), PermissionType.getPermission("EDIT_COLOR"))) {
             colorChangeClick = getGroupColorChangeButton();
         } else {
-            ItemUtils.setComponentLore(colorChangeStack, Component.text("You don't have permission to do this", NamedTextColor.RED));
+            ItemUtils.setComponentLore(colorChangeStack,
+                Component.text("You don't have permission to do this", NamedTextColor.RED)
+                .decoration(TextDecoration.ITALIC, false)
+            );
             colorChangeClick = new DecorationStack(colorChangeStack);
         }
         ci.setSlot(colorChangeClick, 11);
@@ -278,7 +284,10 @@ public class AdminFunctionsGUI extends AbstractGroupGUI {
 
     private LClickable getGroupColorChangeButton() {
         return new LClickable(Material.WHITE_DYE,
-            Component.text("Change group color of ", NamedTextColor.GOLD).append(g.getGroupNameColored()), p -> {
+            Component.text("Change group color of ", NamedTextColor.GOLD)
+                .append(g.getGroupNameColored())
+                .decoration(TextDecoration.ITALIC, false)
+            , p -> {
             ClickableInventory.forceCloseInventory(p);
             p.sendMessage(Component.text("Enter the color you wish to change ", NamedTextColor.GREEN).append(g.getGroupNameColored())
                 .append(Component.text(" to or type \"cancel\" to leave this prompt", NamedTextColor.GREEN)));


### PR DESCRIPTION
Makes text on the white dye for colour changes not italic to align with the rest of the buttons. This will be something to watch out for in the future, it seems Kyori components as item names now default to italicized but the legacy `ItemMeta#setDisplayName` and `ItemMeta#setLore` do not.

Before:
<img width="585" height="319" alt="image" src="https://github.com/user-attachments/assets/f77cf085-68f5-4d6e-9ba8-81ac81270c6c" />


After:
<img width="585" height="319" alt="image" src="https://github.com/user-attachments/assets/68048ce6-62a4-4c31-b2bd-c56ab70b6363" />
