### PR TITLE
Fix emeralds blocking chest interactions

### DIFF
--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/OldEnchanting.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/OldEnchanting.java
@@ -378,9 +378,8 @@ public final class OldEnchanting extends BasicHack {
         }
         if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
             final Block clicked = Objects.requireNonNull(event.getClickedBlock());
-            if (clicked.getType().isInteractable()) {
-                event.setCancelled(true); // Don't give levels if trying to open a chest for example
-                return;
+            if (clicked.getType().isInteractable() && !player.isSneaking()) {
+                return; // Let the block interaction (e.g. chest open) proceed normally
             }
         }
         final int amount = held.getAmount();


### PR DESCRIPTION
Holding an emerald previously cancelled right-click-block events on
any interactable block, preventing chests from opening at all. Mirror
vanilla food behavior instead: if the player is not sneaking, let the
block interaction proceed normally; if sneaking, consume the emerald
for XP as before.
