### PR TITLE
fix dest setting not being saved

### DIFF
--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/ResetSetting.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/ResetSetting.java
@@ -17,7 +17,7 @@ public final class ResetSetting extends StringSetting {
     private final DestinationSetting destinationSetting;
 
     public ResetSetting(JavaPlugin plugin, DestinationSetting destinationSetting) {
-        super(plugin, "", "Clear Destination", "dest", new ItemStack(Material.BARRIER), "Clears your destination.");
+        super(plugin, "", "Clear Destination", "dest-reset-action", new ItemStack(Material.BARRIER), "Clears your destination.");
         this.destinationSetting = destinationSetting;
     }
 


### PR DESCRIPTION
The dest setting fails to save because the reset setting was sometimes overwriting it during the config save. This could have been prevented by not allowing duplicate settings keys from being registered.