### PR TITLE
fix: allow for event cancelling when a wither is constructed

### DIFF
--- a/plugins/bastion-paper/src/main/java/isaac/bastion/listeners/MobListener.java
+++ b/plugins/bastion-paper/src/main/java/isaac/bastion/listeners/MobListener.java
@@ -36,7 +36,7 @@ public class MobListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void on(CreatureSpawnEvent event) {
-        if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) {
+        if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL && event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.BUILD_WITHER) {
             return;
         }
         if (!(event.getEntity() instanceof Monster)) {


### PR DESCRIPTION
## Why?

Current condition allows for the event wither construction to be returned early from the first event type. The intent with this logic allows for the event to be handled elsewhere, but wither spawn events are not later handled, allowing the spawn. 

## Impact

This will block wither constructions inside a mob repellator field. This could be considered breaking change if the theory behind the block is to allow "anyone on the group can still spawn withers". Given the current state, permission checks are not carried out on the namelayer group of the bastion, so friendly players on the group are blocked from spawning withers inside their own bastion field. If this is intended, this PR remedies that.

## LLM:
Not used - one liner change to existing logic. 