### PR TITLE
JSON page deserialization in PrintingPlateJSONRecipe so plates render…

### DIFF
--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateJsonRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateJsonRecipe.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import io.papermc.paper.adventure.PaperAdventure;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.network.Filterable;
 import net.minecraft.server.network.FilteredText;
@@ -83,11 +84,12 @@ public class PrintingPlateJsonRecipe extends PrintingPlateRecipe {
         }
         String serialNumber = UUID.randomUUID().toString();
 
-        List<net.kyori.adventure.text.Component> pages = new ArrayList<>(bookMeta.pages().size());
-        pages.addAll(bookMeta.pages());
+        String[] rawPages = String.join("", bookMeta.getPages()).split("<<PAGE>>");
 
         List<Filterable<Component>> list = new ArrayList<>();
-		for (net.kyori.adventure.text.Component page : pages) {
+
+        for (String rawPage : rawPages) { 
+            net.kyori.adventure.text.Component page = GsonComponentSerializer.gson().deserialize(rawPage);
             list.add(Filterable.passThrough(PaperAdventure.asVanilla(page)));
         }
 


### PR DESCRIPTION
Fixes #923 

Fix made and tested before @Ameliorate suggested the more comprehensive re-write. Seems to solve the bug on cases I tested and may be sufficient to fix the plates being completely busted in the interim.

**Changed**

Converted the text content from books into strings that can be deserialized before the content is added to the `page` Component.

**Why**

If the data isn't deserialized, the serialized JSON just ends up as plaintext.

**Tests**

Tested existing behavior vs post-fix on a locally hosted Civ server. 

| # | Case | Expected | Result |
|---|------|------|----------|
| 1 | Pre-fix, any valid JSON book | Raw JSON verbatim | Bug reproduced |
| 2 | Object JSON `{"text":"X","color":"gold","bold":true}` | Gold + bold "X" | Pass (fixed) |
| 3 | Array JSON `["",{"text":"We"},{"text":"lco","italic":true},{"text":"me t"},{"text":"o Minec","color":"aqua"},{"text":"raft To","bold":true,"color":"aqua"},{"text":"ols","color":"aqua"}]` | Styled render | Pass (fixed) |
| 4 | Hex + all decorations `{"text":"Hex ","color":"#55FF55","extra":[{"text":"B","bold":true},{"text":"I","italic":true}{"text":" U","underlined":true},{"text":"S","strikethrough":true},{"text":" O","obfuscated":true}]}` | Styled render | Pass (fixed) |
| 5 | Keybind + translate `["",{"keybind":"key.jump"},{"text":" / "},{"translate":"menu.singleplayer"}]` | Correct linkage | Pass (fixed) |
| 6 | Hover/click `{"text":"hover me","hoverEvent":{"action":"show_text","contents":{"text":"hi","color":"gold"}},"clickEvent":{"action":"suggest_command","value":"/help"}}` | Hover & clickable text | Semi-passing (hover only)* |
| 7 | Multi-page JSON **page1** `{"text":"Hello` + **page2** `World"}`| "HelloWorld" | Pass (fixed) |
| 8 |Malformed JSON `{"text":"oops"`| "JSON Syntax Error" button, no output | Pass (validator intact) |
| 9 | Banned key `input: {"score":{"name":"@p","objective":"x"}}` | `Banned Tag Error` | Pass (expected error) |
| 10 | Plain prose `hello world` | "JSON Syntax Error" button | Pass (expected error) |

_*Not sure why click events aren't working, didn't investigate. Could be neat to pre-fill chatbox with `/dest` locations if it did but also not why I'm here._

**LLM Disclosure**

Used `claude-opus-4-7`, verified changes and tested outcomes in client on a locally hosted Civ instance.