### PR TITLE
Fix an inconsistency in how primary ownership of namelayer groups is surfaced.

### DIFF
--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/command/commands/ListGroups.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/command/commands/ListGroups.java
@@ -96,7 +96,7 @@ public class ListGroups extends BaseCommandMiddle {
             for (int x = first; x < first + 10 && x < groups.size(); x++) {
                 Group g = GroupManager.getGroup(groups.get(x));
                 sb.append(String.format("%s : (%s)\n",
-                    g.getName(), g.getPlayerType(uuid).toString()));
+                    g.getName(), g.isOwner(uuid) ? "PRIMARY_OWNER" : g.getPlayerType(uuid).toString()));
             }
         }
         sender.sendMessage(sb.toString());

--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/command/commands/ListMembers.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/command/commands/ListMembers.java
@@ -81,7 +81,7 @@ public class ListMembers extends BaseCommandMiddle {
         for (UUID uu : uuids) {
             sb.append(NameLayerAPI.getCurrentName(uu));
             sb.append(" (");
-            sb.append(group.getPlayerType(uu));
+            sb.append(group.isOwner(uu) ? "PRIMARY_OWNER" : group.getPlayerType(uu));
             sb.append(")\n");
         }
 


### PR DESCRIPTION
Currently, when viewing a name-layer group's membership via the GUI, there's special handling to differentiate a typical owner, from the primary owner.

The discrepancy is that in the chat-based counterparts to the GUI command, no special handling is present to mark someone as the primary owner. So this PR adds a one-liner each to the `/nllg` and `/nllm` commands that will check if someone is the primary owner of the group and make their rank show `PRIMARY_OWNER`, which is consistent with the enums currently exposed alongside player names.

Plus, this is really bugging me on a personal level.

**Co-authored by Claude.**