### PR TITLE
Stop coral from drying when reinforced

### DIFF
--- a/ansible/files/paper-config/ops.json
+++ b/ansible/files/paper-config/ops.json
@@ -22,11 +22,5 @@
     "name": "zenron_",
     "level": 4,
     "bypassesPlayerLimit": true
-  },
-  {
-    "uuid": "1cff6d38-b01b-4d0c-b3c6-7a536f616920",
-    "name": "Polysemic",
-    "level": 4,
-    "bypassesPlayerLimit": true
   }
 ]

--- a/ansible/files/paper-config/ops.json
+++ b/ansible/files/paper-config/ops.json
@@ -22,5 +22,11 @@
     "name": "zenron_",
     "level": 4,
     "bypassesPlayerLimit": true
+  },
+  {
+    "uuid": "1cff6d38-b01b-4d0c-b3c6-7a536f616920",
+    "name": "Polysemic",
+    "level": 4,
+    "bypassesPlayerLimit": true
   }
 ]

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -306,28 +306,9 @@ public class BlockListener implements Listener {
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onCoralDry(BlockFadeEvent event) {
         Material type = event.getBlock().getType();
-        Material to = event.getNewState().getType();
 
-        if (!((type == Material.BRAIN_CORAL_BLOCK && to == Material.DEAD_BRAIN_CORAL_BLOCK) ||
-            (type == Material.BUBBLE_CORAL_BLOCK && to == Material.DEAD_BUBBLE_CORAL_BLOCK) ||
-            (type == Material.FIRE_CORAL_BLOCK && to == Material.DEAD_FIRE_CORAL_BLOCK) ||
-            (type == Material.HORN_CORAL_BLOCK && to == Material.DEAD_HORN_CORAL_BLOCK) ||
-            (type == Material.TUBE_CORAL_BLOCK && to == Material.DEAD_TUBE_CORAL_BLOCK) ||
-            (type == Material.BRAIN_CORAL && to == Material.DEAD_BRAIN_CORAL) ||
-            (type == Material.BUBBLE_CORAL && to == Material.DEAD_BUBBLE_CORAL) ||
-            (type == Material.FIRE_CORAL && to == Material.DEAD_FIRE_CORAL) ||
-            (type == Material.HORN_CORAL && to == Material.DEAD_HORN_CORAL) ||
-            (type == Material.TUBE_CORAL && to == Material.DEAD_TUBE_CORAL) ||
-            (type == Material.BRAIN_CORAL_FAN && to == Material.DEAD_BRAIN_CORAL_FAN) ||
-            (type == Material.BUBBLE_CORAL_FAN && to == Material.DEAD_BUBBLE_CORAL_FAN) ||
-            (type == Material.FIRE_CORAL_FAN && to == Material.DEAD_FIRE_CORAL_FAN) ||
-            (type == Material.HORN_CORAL_FAN && to == Material.DEAD_HORN_CORAL_FAN) ||
-            (type == Material.TUBE_CORAL_FAN && to == Material.DEAD_TUBE_CORAL_FAN) ||
-            (type == Material.BRAIN_CORAL_WALL_FAN && to == Material.DEAD_BRAIN_CORAL_WALL_FAN) ||
-            (type == Material.BUBBLE_CORAL_WALL_FAN && to == Material.DEAD_BUBBLE_CORAL_WALL_FAN) ||
-            (type == Material.FIRE_CORAL_WALL_FAN && to == Material.DEAD_FIRE_CORAL_WALL_FAN) ||
-            (type == Material.HORN_CORAL_WALL_FAN && to == Material.DEAD_HORN_CORAL_WALL_FAN) ||
-            (type == Material.TUBE_CORAL_WALL_FAN && to == Material.DEAD_TUBE_CORAL_WALL_FAN))) return;
+        // Corals includes everything except blocks
+        if (!(Tag.CORALS.isTagged(type) || Tag.CORAL_BLOCKS.isTagged(type))) return;
 
         // Note: For non-blocks (fans, wall fans, corals) this will check the block it is placed on instead
         if (ReinforcementLogic.getReinforcementProtecting(event.getBlock()) != null) {

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -307,8 +307,10 @@ public class BlockListener implements Listener {
     public void onCoralDry(BlockFadeEvent event) {
         Material type = event.getBlock().getType();
 
-        // Corals includes everything (fans and coral) except blocks
-        if (!(Tag.CORALS.isTagged(type) || Tag.CORAL_BLOCKS.isTagged(type))) return;
+        // Corals includes everything (fans and coral) except blocks and wall fans, for some reason
+        if (!(Tag.CORALS.isTagged(type) ||
+              Tag.CORAL_BLOCKS.isTagged(type) ||
+              Tag.WALL_CORALS.isTagged(type))) return;
 
         // Note: For non-blocks (fans, wall fans, corals) this will check the block it is placed on instead
         if (ReinforcementLogic.getReinforcementProtecting(event.getBlock()) != null) {

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -33,6 +33,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockBurnEvent;
 import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.block.BlockFadeEvent;
 import org.bukkit.event.block.BlockFertilizeEvent;
 import org.bukkit.event.block.BlockFormEvent;
 import org.bukkit.event.block.BlockFromToEvent;
@@ -298,6 +299,38 @@ public class BlockListener implements Listener {
 
         if (!reinforcement.hasPermission(player, CitadelPermissionHandler.getModifyBlocks())) {
             player.sendMessage(ChatColor.RED + "You do not have permission to modify this block");
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onCoralDry(BlockFadeEvent event) {
+        Material type = event.getBlock().getType();
+        Material to = event.getNewState().getType();
+
+        if (!((type == Material.BRAIN_CORAL_BLOCK && to == Material.DEAD_BRAIN_CORAL_BLOCK) ||
+            (type == Material.BUBBLE_CORAL_BLOCK && to == Material.DEAD_BUBBLE_CORAL_BLOCK) ||
+            (type == Material.FIRE_CORAL_BLOCK && to == Material.DEAD_FIRE_CORAL_BLOCK) ||
+            (type == Material.HORN_CORAL_BLOCK && to == Material.DEAD_HORN_CORAL_BLOCK) ||
+            (type == Material.TUBE_CORAL_BLOCK && to == Material.DEAD_TUBE_CORAL_BLOCK) ||
+            (type == Material.BRAIN_CORAL && to == Material.DEAD_BRAIN_CORAL) ||
+            (type == Material.BUBBLE_CORAL && to == Material.DEAD_BUBBLE_CORAL) ||
+            (type == Material.FIRE_CORAL && to == Material.DEAD_FIRE_CORAL) ||
+            (type == Material.HORN_CORAL && to == Material.DEAD_HORN_CORAL) ||
+            (type == Material.TUBE_CORAL && to == Material.DEAD_TUBE_CORAL) ||
+            (type == Material.BRAIN_CORAL_FAN && to == Material.DEAD_BRAIN_CORAL_FAN) ||
+            (type == Material.BUBBLE_CORAL_FAN && to == Material.DEAD_BUBBLE_CORAL_FAN) ||
+            (type == Material.FIRE_CORAL_FAN && to == Material.DEAD_FIRE_CORAL_FAN) ||
+            (type == Material.HORN_CORAL_FAN && to == Material.DEAD_HORN_CORAL_FAN) ||
+            (type == Material.TUBE_CORAL_FAN && to == Material.DEAD_TUBE_CORAL_FAN) ||
+            (type == Material.BRAIN_CORAL_WALL_FAN && to == Material.DEAD_BRAIN_CORAL_WALL_FAN) ||
+            (type == Material.BUBBLE_CORAL_WALL_FAN && to == Material.DEAD_BUBBLE_CORAL_WALL_FAN) ||
+            (type == Material.FIRE_CORAL_WALL_FAN && to == Material.DEAD_FIRE_CORAL_WALL_FAN) ||
+            (type == Material.HORN_CORAL_WALL_FAN && to == Material.DEAD_HORN_CORAL_WALL_FAN) ||
+            (type == Material.TUBE_CORAL_WALL_FAN && to == Material.DEAD_TUBE_CORAL_WALL_FAN))) return;
+
+        // Note: For non-blocks (fans, wall fans, corals) this will check the block it is placed on instead
+        if (ReinforcementLogic.getReinforcementProtecting(event.getBlock()) != null) {
             event.setCancelled(true);
         }
     }

--- a/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/plugins/citadel-paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -307,7 +307,7 @@ public class BlockListener implements Listener {
     public void onCoralDry(BlockFadeEvent event) {
         Material type = event.getBlock().getType();
 
-        // Corals includes everything except blocks
+        // Corals includes everything (fans and coral) except blocks
         if (!(Tag.CORALS.isTagged(type) || Tag.CORAL_BLOCKS.isTagged(type))) return;
 
         // Note: For non-blocks (fans, wall fans, corals) this will check the block it is placed on instead


### PR DESCRIPTION
Adds a check for reinforcement when coral tries to dry (fade). If the block is reinforced, don't let it turn to its dead variant.

For non-full blocks (e.g. fans, normal coral, wall fans) this checks the block it is on. I'm not sure if having this behavior is desirable for those blocks at all. I'll adjust it to only work on the full blocks if that'd be considered more fitting.

Discord thread: https://discord.com/channels/912074050086502470/1525198619509129347