### PR TITLE
Add owner-controlled arena gravity

### DIFF
--- a/plugins/kitpvp-paper/build.gradle.kts
+++ b/plugins/kitpvp-paper/build.gradle.kts
@@ -17,4 +17,11 @@ dependencies {
     compileOnly(files("../../ansible/src/paper-plugins/BreweryX-3.6.3.jar"))
     compileOnly(libs.aswm.api)
     compileOnly(libs.placeholderapi)
+
+    testImplementation(libs.paper.api)
+    testImplementation(libs.bundles.junit)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/KitPvpPlugin.java
+++ b/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/KitPvpPlugin.java
@@ -5,6 +5,7 @@ import java.util.List;
 import net.civmc.kitpvp.anvil.AnvilGui;
 import net.civmc.kitpvp.arena.ArenaCleaner;
 import net.civmc.kitpvp.arena.ArenaCommand;
+import net.civmc.kitpvp.arena.ArenaGravityListener;
 import net.civmc.kitpvp.arena.ArenaManager;
 import net.civmc.kitpvp.arena.MysqlLoader;
 import net.civmc.kitpvp.arena.PrivateArenaListener;
@@ -39,6 +40,7 @@ import vg.civcraft.mc.civmodcore.dao.ManagedDatasource;
 public class KitPvpPlugin extends ACivMod {
 
     private ManagedDatasource source;
+    private ArenaGravityListener gravityListener;
 
     @Override
     public void onEnable() {
@@ -92,7 +94,10 @@ public class KitPvpPlugin extends ACivMod {
 
             PrivateArenaListener privateArenaListener = new PrivateArenaListener(spawnProvider, manager);
             getServer().getPluginManager().registerEvents(privateArenaListener, this);
-            getCommand("arena").setExecutor(new ArenaCommand(this, arenaDao, ranked, queueManager, manager, privateArenaListener));
+            gravityListener = new ArenaGravityListener(manager, this);
+            gravityListener.resetOnlinePlayers();
+            getServer().getPluginManager().registerEvents(gravityListener, this);
+            getCommand("arena").setExecutor(new ArenaCommand(this, arenaDao, ranked, queueManager, manager, privateArenaListener, gravityListener));
             getServer().getPluginManager().registerEvents(new RespawnListener(manager, this), this);
             Bukkit.getScheduler().runTaskTimer(this, new ArenaCleaner(manager), 20 * 60, 20 * 60);
         } catch (SQLException e) {
@@ -102,6 +107,9 @@ public class KitPvpPlugin extends ACivMod {
 
     @Override
     public void onDisable() {
+        if (gravityListener != null) {
+            gravityListener.resetOnlinePlayers();
+        }
         this.source.close();
     }
 }

--- a/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/ArenaCommand.java
+++ b/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/ArenaCommand.java
@@ -32,14 +32,16 @@ public class ArenaCommand implements CommandExecutor {
     private final RankedQueueManager rankedQueueManager;
     private final ArenaManager manager;
     private final PrivateArenaListener privateArenaListener;
+    private final ArenaGravityListener gravityListener;
 
-    public ArenaCommand(JavaPlugin plugin, ArenaDao dao, RankedDao rankedDao, RankedQueueManager rankedQueueManager, ArenaManager manager, PrivateArenaListener privateArenaListener) {
+    public ArenaCommand(JavaPlugin plugin, ArenaDao dao, RankedDao rankedDao, RankedQueueManager rankedQueueManager, ArenaManager manager, PrivateArenaListener privateArenaListener, ArenaGravityListener gravityListener) {
         this.plugin = plugin;
         this.dao = dao;
         this.rankedDao = rankedDao;
         this.rankedQueueManager = rankedQueueManager;
         this.manager = manager;
         this.privateArenaListener = privateArenaListener;
+        this.gravityListener = gravityListener;
     }
 
     @Override
@@ -171,18 +173,14 @@ public class ArenaCommand implements CommandExecutor {
             manager.setMaxArenas(arenas);
             player.sendMessage(Component.text("Set arena cap to " + arenas, NamedTextColor.GREEN));
             return true;
+        } else if (args.length > 0 && args[0].equalsIgnoreCase("gravity")) {
+            return gravity(player, args);
         } else if (args.length > 0 && args[0].equalsIgnoreCase("add")) {
             if (args.length < 2) {
                 return false;
             }
 
-            LoadedArena playerArena = null;
-            for (LoadedArena arena : manager.getArenas()) {
-                if (!arena.ranked() && arena.owner().equals(player.getPlayerProfile())) {
-                    playerArena = arena;
-                    break;
-                }
-            }
+            LoadedArena playerArena = manager.getOwnedArena(player);
             if (playerArena == null) {
                 player.sendMessage(Component.text("You do not currently have an arena", NamedTextColor.RED));
                 return true;
@@ -219,13 +217,7 @@ public class ArenaCommand implements CommandExecutor {
                 return false;
             }
 
-            LoadedArena playerArena = null;
-            for (LoadedArena arena : manager.getArenas()) {
-                if (!arena.ranked() && arena.owner().equals(player.getPlayerProfile())) {
-                    playerArena = arena;
-                    break;
-                }
-            }
+            LoadedArena playerArena = manager.getOwnedArena(player);
             if (playerArena == null) {
                 player.sendMessage(Component.text("You do not currently have an arena", NamedTextColor.RED));
                 return true;
@@ -263,11 +255,45 @@ public class ArenaCommand implements CommandExecutor {
             Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
                 double elo = rankedDao.getElo(player.getUniqueId());
                 Bukkit.getScheduler().runTask(plugin, () -> {
-                    new ArenaGui(dao, rankedQueueManager, elo, manager).open(player);
+                    new ArenaGui(dao, rankedQueueManager, elo, manager, gravityListener).open(player);
                 });
             });
             return true;
         }
         return false;
+    }
+
+    private boolean gravity(Player player, String[] args) {
+        if (args.length != 1 && args.length != 2) {
+            return false;
+        }
+
+        LoadedArena arena = manager.getOwnedArena(player);
+        if (arena == null) {
+            player.sendMessage(Component.text("You do not currently own an arena", NamedTextColor.RED));
+            return true;
+        }
+
+        if (args.length == 1) {
+            Component message = Component.text("Arena gravity: " + arena.gravity().displayName() + " (" + arena.gravity().value() + ")", NamedTextColor.GREEN);
+            if (arena.gravityLocked()) {
+                message = message.append(Component.text(" (locked)", NamedTextColor.RED));
+            }
+            player.sendMessage(message);
+            return true;
+        }
+
+        ArenaGravity gravity = ArenaGravity.parse(args[1]).orElse(null);
+        if (gravity == null) {
+            player.sendMessage(Component.text("Gravity must be main or zorweth", NamedTextColor.RED));
+            return true;
+        }
+        if (!arena.setGravity(gravity)) {
+            player.sendMessage(Component.text("Arena gravity is locked because another player has joined", NamedTextColor.RED));
+            return true;
+        }
+        gravityListener.refresh(player);
+        player.sendMessage(Component.text("Set arena gravity to " + gravity.displayName(), NamedTextColor.GREEN));
+        return true;
     }
 }

--- a/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/ArenaGravity.java
+++ b/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/ArenaGravity.java
@@ -1,0 +1,40 @@
+package net.civmc.kitpvp.arena;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public enum ArenaGravity {
+    MAIN("Main", 0.08D),
+    ZORWETH("Zorweth", 0.04D);
+
+    private final String displayName;
+    private final double value;
+
+    ArenaGravity(String displayName, double value) {
+        this.displayName = displayName;
+        this.value = value;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    public double value() {
+        return value;
+    }
+
+    public ArenaGravity alternate() {
+        return this == MAIN ? ZORWETH : MAIN;
+    }
+
+    public static Optional<ArenaGravity> parse(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(valueOf(value.toUpperCase(Locale.ROOT)));
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
+}

--- a/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/ArenaGravityListener.java
+++ b/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/ArenaGravityListener.java
@@ -1,0 +1,78 @@
+package net.civmc.kitpvp.arena;
+
+import org.bukkit.GameMode;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerGameModeChangeEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class ArenaGravityListener implements Listener {
+
+    private final ArenaManager manager;
+    private final JavaPlugin plugin;
+
+    public ArenaGravityListener(ArenaManager manager, JavaPlugin plugin) {
+        this.manager = manager;
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void on(PlayerChangedWorldEvent event) {
+        refresh(event.getPlayer());
+    }
+
+    @EventHandler
+    public void on(PlayerGameModeChangeEvent event) {
+        plugin.getServer().getScheduler().runTask(plugin, () -> refresh(event.getPlayer()));
+    }
+
+    @EventHandler
+    public void on(PlayerJoinEvent event) {
+        refresh(event.getPlayer());
+    }
+
+    @EventHandler
+    public void on(PlayerRespawnEvent event) {
+        plugin.getServer().getScheduler().runTask(plugin, () -> refresh(event.getPlayer()));
+    }
+
+    @EventHandler
+    public void on(PlayerQuitEvent event) {
+        resetGravity(event.getPlayer());
+    }
+
+    public void refresh(Player player) {
+        LoadedArena arena = manager.getArena(player.getWorld().getName());
+        if (arena == null || arena.ranked() || player.getGameMode() != GameMode.SURVIVAL) {
+            resetGravity(player);
+            return;
+        }
+
+        setGravity(player, arena.gravity());
+        if (!arena.owner().getId().equals(player.getUniqueId())) {
+            arena.lockGravity();
+        }
+    }
+
+    public void resetOnlinePlayers() {
+        plugin.getServer().getOnlinePlayers().forEach(this::resetGravity);
+    }
+
+    private void resetGravity(Player player) {
+        setGravity(player, ArenaGravity.MAIN);
+    }
+
+    private void setGravity(Player player, ArenaGravity gravity) {
+        AttributeInstance attribute = player.getAttribute(Attribute.GRAVITY);
+        if (attribute != null) {
+            attribute.setBaseValue(gravity.value());
+        }
+    }
+}

--- a/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/ArenaManager.java
+++ b/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/ArenaManager.java
@@ -70,6 +70,24 @@ public class ArenaManager {
         return new ArrayList<>(arenas.sequencedValues());
     }
 
+    public LoadedArena getOwnedArena(Player player) {
+        return arenas.get(player.getUniqueId());
+    }
+
+    public LoadedArena getArena(String worldName) {
+        for (LoadedArena arena : arenas.values()) {
+            if (getArenaName(arena).equals(worldName)) {
+                return arena;
+            }
+        }
+        for (LoadedArena arena : rankedArenas) {
+            if (getArenaName(arena).equals(worldName)) {
+                return arena;
+            }
+        }
+        return null;
+    }
+
     public void deleteArena(PlayerProfile owner) {
         LoadedArena removedArena = arenas.remove(owner.getId());
         if (removedArena == null) {

--- a/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/LoadedArena.java
+++ b/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/LoadedArena.java
@@ -4,13 +4,60 @@ import com.destroystokyo.paper.profile.PlayerProfile;
 import net.civmc.kitpvp.arena.data.Arena;
 import java.util.List;
 
-public record LoadedArena(
-    PlayerProfile owner,
-    Arena arena,
-    List<PlayerProfile> invitedPlayers,
-    int rankedId
-) {
+public final class LoadedArena {
+
+    private final PlayerProfile owner;
+    private final Arena arena;
+    private final List<PlayerProfile> invitedPlayers;
+    private final int rankedId;
+    private ArenaGravity gravity;
+    private boolean gravityLocked;
+
+    public LoadedArena(PlayerProfile owner, Arena arena, List<PlayerProfile> invitedPlayers, int rankedId) {
+        this.owner = owner;
+        this.arena = arena;
+        this.invitedPlayers = invitedPlayers;
+        this.rankedId = rankedId;
+        this.gravity = ArenaGravity.MAIN;
+    }
+
+    public PlayerProfile owner() {
+        return owner;
+    }
+
+    public Arena arena() {
+        return arena;
+    }
+
+    public List<PlayerProfile> invitedPlayers() {
+        return invitedPlayers;
+    }
+
+    public int rankedId() {
+        return rankedId;
+    }
+
     public boolean ranked() {
         return rankedId >= 0;
+    }
+
+    public ArenaGravity gravity() {
+        return gravity;
+    }
+
+    public boolean gravityLocked() {
+        return gravityLocked;
+    }
+
+    public boolean setGravity(ArenaGravity gravity) {
+        if (gravityLocked) {
+            return false;
+        }
+        this.gravity = gravity;
+        return true;
+    }
+
+    public void lockGravity() {
+        this.gravityLocked = true;
     }
 }

--- a/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/gui/ArenaGui.java
+++ b/plugins/kitpvp-paper/src/main/java/net/civmc/kitpvp/arena/gui/ArenaGui.java
@@ -3,6 +3,7 @@ package net.civmc.kitpvp.arena.gui;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import net.civmc.kitpvp.arena.ArenaGravityListener;
 import net.civmc.kitpvp.arena.ArenaManager;
 import net.civmc.kitpvp.arena.LoadedArena;
 import net.civmc.kitpvp.arena.data.Arena;
@@ -32,12 +33,14 @@ public class ArenaGui {
     private final RankedQueueManager rankedQueueManager;
     private final double elo;
     private final ArenaManager manager;
+    private final ArenaGravityListener gravityListener;
 
-    public ArenaGui(ArenaDao dao, RankedQueueManager rankedQueueManager, double elo, ArenaManager manager) {
+    public ArenaGui(ArenaDao dao, RankedQueueManager rankedQueueManager, double elo, ArenaManager manager, ArenaGravityListener gravityListener) {
         this.dao = dao;
         this.rankedQueueManager = rankedQueueManager;
         this.elo = elo;
         this.manager = manager;
+        this.gravityListener = gravityListener;
     }
 
     public void open(Player player) {
@@ -80,6 +83,15 @@ public class ArenaGui {
             }
             lore.add(Component.text("Click to teleport", NamedTextColor.AQUA).decoration(TextDecoration.ITALIC, false));
             lore.add(Component.text("Shift left click to join as spectator", NamedTextColor.AQUA).decoration(TextDecoration.ITALIC, false));
+            String gravityLore = "Gravity: " + loadedArena.gravity().displayName();
+            NamedTextColor gravityColour = NamedTextColor.AQUA;
+            if (isOwner && loadedArena.gravityLocked()) {
+                gravityLore += " [Locked]";
+                gravityColour = NamedTextColor.RED;
+            } else if (isOwner) {
+                gravityLore += " [Right-click: " + loadedArena.gravity().alternate().displayName() + "]";
+            }
+            lore.add(Component.text(gravityLore, gravityColour).decoration(TextDecoration.ITALIC, false));
             if (hasAccess) {
                 lore.add(Component.text("Shift right click to delete", NamedTextColor.AQUA).decoration(TextDecoration.ITALIC, false));
             }
@@ -112,6 +124,21 @@ public class ArenaGui {
                         player.setGameMode(GameMode.SPECTATOR);
                         player.teleport(arena.spawn().toLocation(world));
                     }
+                }
+
+                @Override
+                protected void onRightClick(@NotNull Player clicker) {
+                    if (!isOwner) {
+                        super.onRightClick(clicker);
+                        return;
+                    }
+                    if (!loadedArena.setGravity(loadedArena.gravity().alternate())) {
+                        clicker.sendMessage(Component.text("Arena gravity is locked because another player has joined", NamedTextColor.RED));
+                        return;
+                    }
+                    gravityListener.refresh(clicker);
+                    clicker.sendMessage(Component.text("Set arena gravity to " + loadedArena.gravity().displayName(), NamedTextColor.GREEN));
+                    open(clicker);
                 }
 
                 @Override

--- a/plugins/kitpvp-paper/src/main/resources/plugin.yml
+++ b/plugins/kitpvp-paper/src/main/resources/plugin.yml
@@ -24,6 +24,7 @@ commands:
       /<command> delete <name> (administrators only)
       /<command> displayname <name> <display name> (administrators only)
       /<command> category <name> <category> (administrators only)
+      /<command> gravity [main|zorweth]
       /<command> cap <arenas> (administrators only)
   spawn: {}
   setspawn:

--- a/plugins/kitpvp-paper/src/test/java/net/civmc/kitpvp/arena/ArenaGravityTest.java
+++ b/plugins/kitpvp-paper/src/test/java/net/civmc/kitpvp/arena/ArenaGravityTest.java
@@ -1,0 +1,62 @@
+package net.civmc.kitpvp.arena;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.civmc.kitpvp.arena.data.Arena;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+class ArenaGravityTest {
+
+    @Test
+    void parsesGravityNamesCaseInsensitively() {
+        assertEquals(ArenaGravity.MAIN, ArenaGravity.parse("main").orElseThrow());
+        assertEquals(ArenaGravity.ZORWETH, ArenaGravity.parse("ZoRwEtH").orElseThrow());
+    }
+
+    @Test
+    void rejectsUnknownGravityNames() {
+        assertTrue(ArenaGravity.parse("moon").isEmpty());
+        assertTrue(ArenaGravity.parse(null).isEmpty());
+    }
+
+    @Test
+    void usesExpectedServerGravityValues() {
+        assertEquals(0.08D, ArenaGravity.MAIN.value());
+        assertEquals(0.04D, ArenaGravity.ZORWETH.value());
+    }
+
+    @Test
+    void alternatesBetweenGravitySettings() {
+        assertEquals(ArenaGravity.ZORWETH, ArenaGravity.MAIN.alternate());
+        assertEquals(ArenaGravity.MAIN, ArenaGravity.ZORWETH.alternate());
+    }
+
+    @Test
+    void newArenaStartsWithMainGravityUnlocked() {
+        LoadedArena loaded = newLoadedArena();
+
+        assertEquals(ArenaGravity.MAIN, loaded.gravity());
+        assertFalse(loaded.gravityLocked());
+    }
+
+    @Test
+    void preventsGravityChangesAfterLocking() {
+        LoadedArena loaded = newLoadedArena();
+
+        assertTrue(loaded.setGravity(ArenaGravity.ZORWETH));
+        assertEquals(ArenaGravity.ZORWETH, loaded.gravity());
+
+        loaded.lockGravity();
+
+        assertFalse(loaded.setGravity(ArenaGravity.MAIN));
+        assertEquals(ArenaGravity.ZORWETH, loaded.gravity());
+    }
+
+    private static LoadedArena newLoadedArena() {
+        Arena arena = new Arena("test", null, null, null, Material.STONE);
+        return new LoadedArena(null, arena, null, -1);
+    }
+}


### PR DESCRIPTION
Let arena owners switch between Main and Zorweth gravity before another player joins. Apply the selected gravity to survival players and restore Main gravity when they leave the arena or stop playing.

Show the setting on each arena entry and let its owner toggle it with a right click. Keep ranked arenas and spectators on Main gravity, and cover the gravity values, parsing, toggling, defaults, and lock behavior.