### PR TITLE
Add Brew Packer factory to make BreweryX brews stackable

### DIFF
--- a/ansible/files/paper-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/paper-config/plugins/FactoryMod/config.yml
@@ -1750,6 +1750,39 @@ factories:
       - make_compact_repair_kit
       - repair_compactor
       - repair_compactor_kit
+  brew_packer:
+    type: FCC
+    name: Brew Packer
+    citadelBreakReduction: 0.8
+    setupcost:
+      glass:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GLASS
+        amount: 64
+      copper:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: COPPER_INGOT
+        amount: 32
+      barrel:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 16
+      crate:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: CHEST
+        amount: 8
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          lore:
+            - Crate
+    recipes:
+      - pack_brews
+      - repair_brew_packer
   printing_press:
     type: FCC
     name: Printing Press
@@ -12116,6 +12149,58 @@ recipes:
     type: DECOMPACT
     input:
     compact_lore: Compacted Item
+  pack_brews:
+    production_time: 2s
+    fuel_consumption_intervall: 4s
+    name: Pack Brews
+    type: BREW_STACK
+    input:
+      glass_bottle:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GLASS_BOTTLE
+        amount: 1
+    max_stack_size: 16
+    seal_unsealed: true
+    packed_lore: Packed Brew ({size})
+    allowed_brews:
+      wheatbeer: 16
+      beer: 16
+      darkbeer: 16
+      mead: 8
+      whiskey: 8
+      vodka: 4
+  repair_brew_packer:
+    production_time: 4s
+    name: Repair Factory
+    type: REPAIR
+    input:
+      glass:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GLASS
+        amount: 8
+      copper:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: COPPER_INGOT
+        amount: 4
+      barrel:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 2
+      crate:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: CHEST
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          lore:
+            - Crate
+    health_gained: 10000
   repair_compactor:
     production_time: 4s
     name: Repair Factory

--- a/ansible/files/zorweth-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/zorweth-config/plugins/FactoryMod/config.yml
@@ -1750,6 +1750,39 @@ factories:
       - make_compact_repair_kit
       - repair_compactor
       - repair_compactor_kit
+  brew_packer:
+    type: FCC
+    name: Brew Packer
+    citadelBreakReduction: 0.8
+    setupcost:
+      glass:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GLASS
+        amount: 64
+      copper:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: COPPER_INGOT
+        amount: 32
+      barrel:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 16
+      crate:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: CHEST
+        amount: 8
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          lore:
+            - Crate
+    recipes:
+      - pack_brews
+      - repair_brew_packer
   printing_press:
     type: FCC
     name: Printing Press
@@ -12116,6 +12149,58 @@ recipes:
     type: DECOMPACT
     input:
     compact_lore: Compacted Item
+  pack_brews:
+    production_time: 2s
+    fuel_consumption_intervall: 4s
+    name: Pack Brews
+    type: BREW_STACK
+    input:
+      glass_bottle:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GLASS_BOTTLE
+        amount: 1
+    max_stack_size: 16
+    seal_unsealed: true
+    packed_lore: Packed Brew ({size})
+    allowed_brews:
+      wheatbeer: 16
+      beer: 16
+      darkbeer: 16
+      mead: 8
+      whiskey: 8
+      vodka: 4
+  repair_brew_packer:
+    production_time: 4s
+    name: Repair Factory
+    type: REPAIR
+    input:
+      glass:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GLASS
+        amount: 8
+      copper:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: COPPER_INGOT
+        amount: 4
+      barrel:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: BARREL
+        amount: 2
+      crate:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: CHEST
+        amount: 1
+        meta:
+          meta-type: UNSPECIFIC
+          ==: ItemMeta
+          lore:
+            - Crate
+    health_gained: 10000
   repair_compactor:
     production_time: 4s
     name: Repair Factory

--- a/plugins/factorymod-paper/build.gradle.kts
+++ b/plugins/factorymod-paper/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
     compileOnly(project(":plugins:heliodor-paper"))
     compileOnly(project(":plugins:zorweth-paper"))
     compileOnly(libs.worldedit)
+    compileOnly(files("../../ansible/src/paper-plugins/BreweryX-3.6.3.jar"))
 }

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/ConfigParser.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/ConfigParser.java
@@ -27,6 +27,7 @@ import com.github.igotyou.FactoryMod.recipes.RecipeScalingUpgradeRecipe;
 import com.github.igotyou.FactoryMod.recipes.RepairRecipe;
 import com.github.igotyou.FactoryMod.recipes.Upgraderecipe;
 import com.github.igotyou.FactoryMod.recipes.WordBankRecipe;
+import com.github.igotyou.FactoryMod.recipes.brewery.StackableBrewRecipe;
 import com.github.igotyou.FactoryMod.recipes.heliodor.HeliodorCreateRecipe;
 import com.github.igotyou.FactoryMod.recipes.heliodor.HeliodorFinishRecipe;
 import com.github.igotyou.FactoryMod.recipes.heliodor.HeliodorRefillRecipe;
@@ -64,8 +65,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -674,6 +677,36 @@ public class ConfigParser {
                 manager.addCompactLore(decompactedLore);
                 result = new DecompactingRecipe(identifier, input, name, productionTime, decompactedLore);
                 break;
+            case "BREW_STACK":
+                if (!Bukkit.getPluginManager().isPluginEnabled("BreweryX")) {
+                    plugin.warning("BreweryX plugin must be enabled for brew stacking recipes");
+                    result = null;
+                    break;
+                }
+                int brewStackSize = config.getInt("max_stack_size",
+                    (parentRecipe instanceof StackableBrewRecipe) ? ((StackableBrewRecipe) parentRecipe).getDefaultStackSize()
+                        : 16);
+                if (!isValidBrewStackSize(brewStackSize)) {
+                    plugin.warning("Invalid max_stack_size " + brewStackSize + " for brew stacking recipe " + name
+                        + ", it must be between 2 and 99. The recipe was skipped");
+                    result = null;
+                    break;
+                }
+                boolean sealUnsealedBrews = config.getBoolean("seal_unsealed",
+                    !(parentRecipe instanceof StackableBrewRecipe)
+                        || ((StackableBrewRecipe) parentRecipe).isSealUnsealed());
+                String brewPackedLore = config.getString("packed_lore",
+                    (parentRecipe instanceof StackableBrewRecipe) ? ((StackableBrewRecipe) parentRecipe).getPackedLore()
+                        : null);
+                Map<String, Integer> allowedBrews = parseAllowedBrews(config, brewStackSize, parentRecipe);
+                if (allowedBrews.isEmpty()) {
+                    plugin.warning("No allowed_brews specified for brew stacking recipe " + name + ", it was skipped");
+                    result = null;
+                    break;
+                }
+                result = new StackableBrewRecipe(identifier, name, productionTime, input, allowedBrews, brewStackSize,
+                    sealUnsealedBrews, brewPackedLore);
+                break;
             case "REPAIR":
                 int health = config.getInt("health_gained",
                     (parentRecipe instanceof RepairRecipe) ? ((RepairRecipe) parentRecipe).getHealth() : 0);
@@ -1044,6 +1077,53 @@ public class ConfigParser {
             plugin.info("Parsed recipe " + name);
         }
         return result;
+    }
+
+    /**
+     * Parses the allow list of a brew stacking recipe, keyed by BreweryX brew id. Accepts either a plain list of ids
+     * which all use defaultStackSize, or a mapping of id to stack size where an entry may also be a section carrying
+     * max_stack_size. Falls back to the parent recipe's list when neither is present.
+     * <p>
+     * The ids are not checked against BreweryX here, because it loads after us and has no brews registered yet.
+     * {@link StackableBrewRecipe} warns about unknown ids on first use instead.
+     *
+     * @return Map of lower case brew id to the stack size configured for it
+     */
+    private Map<String, Integer> parseAllowedBrews(ConfigurationSection config, int defaultStackSize,
+                                                   IRecipe parentRecipe) {
+        Map<String, Integer> result = new LinkedHashMap<>();
+        if (config.isList("allowed_brews")) {
+            for (String id : config.getStringList("allowed_brews")) {
+                result.put(id.toLowerCase(Locale.ROOT), defaultStackSize);
+            }
+            return result;
+        }
+        ConfigurationSection section = config.getConfigurationSection("allowed_brews");
+        if (section == null) {
+            if (parentRecipe instanceof StackableBrewRecipe) {
+                result.putAll(((StackableBrewRecipe) parentRecipe).copyAllowedBrews());
+            }
+            return result;
+        }
+        for (String id : section.getKeys(false)) {
+            int stackSize = section.isConfigurationSection(id)
+                ? section.getInt(id + ".max_stack_size", defaultStackSize)
+                : section.getInt(id, defaultStackSize);
+            if (!isValidBrewStackSize(stackSize)) {
+                plugin.warning("Invalid max_stack_size " + stackSize + " for brew " + id + " at "
+                    + config.getCurrentPath() + ", it must be between 2 and 99. The brew was skipped");
+                continue;
+            }
+            result.put(id.toLowerCase(Locale.ROOT), stackSize);
+        }
+        return result;
+    }
+
+    /**
+     * One would leave the brew as unstackable as it already was, and the item meta rejects anything above 99 anyway
+     */
+    private static boolean isValidBrewStackSize(int stackSize) {
+        return stackSize >= 2 && stackSize <= 99;
     }
 
     private static ItemStack parseFirstItem(ConfigurationSection config) {

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/FactoryMod.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/FactoryMod.java
@@ -1,10 +1,12 @@
 package com.github.igotyou.FactoryMod;
 
 import com.github.igotyou.FactoryMod.commands.FMCommandManager;
+import com.github.igotyou.FactoryMod.listeners.BrewStackListener;
 import com.github.igotyou.FactoryMod.listeners.CitadelListener;
 import com.github.igotyou.FactoryMod.listeners.CompactItemListener;
 import com.github.igotyou.FactoryMod.listeners.FactoryModListener;
 import com.github.igotyou.FactoryMod.utility.FactoryModPermissionManager;
+import org.bukkit.Bukkit;
 import vg.civcraft.mc.civmodcore.ACivMod;
 
 public class FactoryMod extends ACivMod {
@@ -56,6 +58,9 @@ public class FactoryMod extends ACivMod {
                 new CompactItemListener(), plugin);
         if (manager.isCitadelEnabled()) {
             plugin.getServer().getPluginManager().registerEvents(new CitadelListener(), plugin);
+        }
+        if (Bukkit.getPluginManager().isPluginEnabled("BreweryX")) {
+            plugin.getServer().getPluginManager().registerEvents(new BrewStackListener(), plugin);
         }
     }
 }

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/listeners/BrewStackListener.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/listeners/BrewStackListener.java
@@ -1,0 +1,43 @@
+package com.github.igotyou.FactoryMod.listeners;
+
+import com.dre.brewery.Brew;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Makes drinking off a stack of brews take a single bottle, the way eating from a stack of food does.
+ * <p>
+ * BreweryX swaps the potion for a plain one so vanilla doesn't apply its effects, which means the server finishes using
+ * that replacement instead of the held stack and puts the result in the hand slot. That overwrites the whole stack, so
+ * without this a player drinking one brew off a stack of sixteen would be left holding a single glass bottle. Setting
+ * the event's replacement decides what ends up in the hand, so the rest of the stack is put back there and the empty
+ * bottle is handed over separately, since overriding the replacement drops the one the server made.
+ * <p>
+ * Runs after BreweryX's own handler, which sits on HIGHEST, so that a drink it refused is left well alone.
+ */
+public class BrewStackListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onBrewStackConsume(PlayerItemConsumeEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        Player player = event.getPlayer();
+        ItemStack held = player.getInventory().getItem(event.getHand());
+        if (held == null || held.getType() != Material.POTION || held.getAmount() <= 1 || !Brew.isBrew(held)) {
+            return;
+        }
+        ItemStack remaining = held.clone();
+        remaining.setAmount(held.getAmount() - 1);
+        event.setReplacement(remaining);
+
+        ItemStack bottle = new ItemStack(Material.GLASS_BOTTLE);
+        player.getInventory().addItem(bottle).values()
+            .forEach(leftover -> player.getWorld().dropItem(player.getLocation(), leftover));
+    }
+}

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/brewery/StackableBrewRecipe.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/recipes/brewery/StackableBrewRecipe.java
@@ -1,0 +1,317 @@
+package com.github.igotyou.FactoryMod.recipes.brewery;
+
+import com.dre.brewery.Brew;
+import com.dre.brewery.recipe.BRecipe;
+import com.github.igotyou.FactoryMod.FactoryMod;
+import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
+import com.github.igotyou.FactoryMod.recipes.EffectFeasibility;
+import com.github.igotyou.FactoryMod.recipes.InputRecipe;
+import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import vg.civcraft.mc.civmodcore.inventory.ClonedInventory;
+import vg.civcraft.mc.civmodcore.inventory.InventoryUtils;
+import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
+
+/**
+ * Used to make BreweryX brews stackable. Brews are potions, which vanilla caps at a stack size of one, so a single
+ * bottle occupies a whole inventory slot. This recipe takes one brew at a time and hands back the very same brew with
+ * the vanilla max stack size component set on it, so bottles of it merge into a single slot from then on. Only brews
+ * whose BreweryX recipe id is on the configured allow list are accepted, each with its own stack size.
+ * <p>
+ * A brew has to be sealed before it can stack at all, because BreweryX writes a fresh random scramble id into an
+ * unsealed brew every time it saves it and no two of those are ever equal.
+ */
+public class StackableBrewRecipe extends InputRecipe {
+
+    /**
+     * Substituted per item rather than per recipe, because the allow list can give every brew its own size
+     */
+    private static final String SIZE_PLACEHOLDER = "{size}";
+
+    private final Map<String, Integer> allowedBrews;
+    private final int defaultStackSize;
+    private final boolean sealUnsealed;
+    private final String packedLore;
+    private boolean validated;
+
+    public StackableBrewRecipe(String identifier, String name, int productionTime, ItemMap input,
+                               Map<String, Integer> allowedBrews, int defaultStackSize, boolean sealUnsealed,
+                               String packedLore) {
+        super(identifier, name, productionTime, input);
+        this.allowedBrews = allowedBrews;
+        this.defaultStackSize = defaultStackSize;
+        this.sealUnsealed = sealUnsealed;
+        this.packedLore = packedLore;
+    }
+
+    @Override
+    public boolean enoughMaterialAvailable(Inventory inputInv) {
+        return input.isContainedIn(inputInv) && findCandidate(inputInv) != null;
+    }
+
+    @Override
+    public EffectFeasibility evaluateEffectFeasibility(Inventory inputInv, Inventory outputInv, FurnCraftChestFactory fccf) {
+        Candidate candidate = findCandidate(inputInv);
+        if (candidate == null) {
+            return new EffectFeasibility(true, null);
+        }
+        // An unsealed preview never merges into a stack already in the chest, so this can claim the chest is full when
+        // one more would have squeezed in. That beats sealing somebody's brew just to answer a question
+        if (!InventoryUtils.safelyAddItemsToInventory(
+            ClonedInventory.cloneInventory(outputInv), new ItemStack[]{preview(candidate)})) {
+            return new EffectFeasibility(false, "it ran out of storage space");
+        }
+        return new EffectFeasibility(true, null);
+    }
+
+    @Override
+    public boolean applyEffect(Inventory inputInv, Inventory outputInv, FurnCraftChestFactory fccf) {
+        MultiInventoryWrapper combo = new MultiInventoryWrapper(inputInv, outputInv);
+        logBeforeRecipeRun(combo, fccf);
+        if (input.isContainedIn(inputInv)) {
+            Candidate candidate = findCandidate(inputInv);
+            if (candidate != null) {
+                ItemStack packed = pack(candidate);
+                if (packed != null) {
+                    if (!InventoryUtils.safelyAddItemsToInventory(
+                        ClonedInventory.cloneInventory(outputInv), new ItemStack[]{packed})) {
+                        return false; // does not fit in chest
+                    }
+                    ItemStack toRemove = candidate.source().clone();
+                    toRemove.setAmount(1);
+                    if (input.removeSafelyFrom(inputInv)) {
+                        if (new ItemMap(toRemove).removeSafelyFrom(inputInv)) {
+                            outputInv.addItem(packed);
+                        }
+                    }
+                }
+            }
+        }
+        logAfterRecipeRun(combo, fccf);
+        return true;
+    }
+
+    /**
+     * Finds the first brew this recipe is willing to make stackable, or null if there is none. Iterates in inventory
+     * order rather than over an ItemMap so the factory always picks the brew a player would expect from the chest.
+     */
+    private Candidate findCandidate(Inventory inputInv) {
+        if (!Bukkit.getPluginManager().isPluginEnabled("BreweryX")) {
+            return null;
+        }
+        validateAllowedBrews();
+        for (ItemStack is : inputInv.getContents()) {
+            if (is == null || is.getType() != Material.POTION) {
+                continue;
+            }
+            if (input.getAmount(is) != 0) {
+                continue; // never eat our own running cost
+            }
+            if (is.getItemMeta().hasMaxStackSize()) {
+                continue; // already stackable, don't charge for it twice
+            }
+            Brew brew = Brew.get(is);
+            if (brew == null || brew.getCurrentRecipe() == null) {
+                continue;
+            }
+            if (!brew.isSealed() && !sealUnsealed) {
+                continue;
+            }
+            Integer stackSize = resolveStackSize(brew.getCurrentRecipe());
+            if (stackSize != null) {
+                return new Candidate(is, stackSize);
+            }
+        }
+        return null;
+    }
+
+    private @Nullable Integer resolveStackSize(BRecipe recipe) {
+        String id = recipe.getId();
+        return id == null ? null : allowedBrews.get(id.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Produces the stackable brew to hand back, sealing it first if needed, or null if it couldn't be sealed. Sealing
+     * has to come first because it rewrites the whole potion meta. It also fires an event and cannot be undone, so this
+     * is only called while actually running the recipe; use {@link #preview(Candidate)} to merely inspect the result.
+     */
+    private @Nullable ItemStack pack(Candidate candidate) {
+        ItemStack result = candidate.source().clone();
+        result.setAmount(1);
+        Brew brew = Brew.get(result);
+        if (brew == null) {
+            return null;
+        }
+        if (!brew.isSealed()) {
+            brew.seal(result, null);
+            // Sealing silently restores the original meta if its event gets cancelled, so reading the brew back off the
+            // item is the only reliable way to tell whether it took
+            Brew sealed = Brew.get(result);
+            if (sealed == null || !sealed.isSealed()) {
+                return null;
+            }
+        }
+        makeStackable(result, candidate.maxStackSize());
+        return result;
+    }
+
+    /**
+     * Same as {@link #pack(Candidate)} but without sealing, for fit checks and gui display. Both happen outside a
+     * recipe run, where sealing the player's brew would be an unwelcome surprise.
+     */
+    private ItemStack preview(Candidate candidate) {
+        ItemStack result = candidate.source().clone();
+        result.setAmount(1);
+        makeStackable(result, candidate.maxStackSize());
+        return result;
+    }
+
+    private void makeStackable(ItemStack is, int maxStackSize) {
+        is.editMeta(meta -> {
+            meta.setMaxStackSize(maxStackSize);
+            if (packedLore != null && !packedLore.isBlank()) {
+                List<Component> lore = meta.hasLore() ? meta.lore() : new ArrayList<>();
+                lore.add(Component.text(packedLore.replace(SIZE_PLACEHOLDER, String.valueOf(maxStackSize))));
+                meta.lore(lore);
+            }
+        });
+    }
+
+    /**
+     * Warns once about allow list entries BreweryX doesn't know, so a typo doesn't just leave the factory quietly doing
+     * nothing. BreweryX loads after us, so this can't happen while parsing the config.
+     */
+    private void validateAllowedBrews() {
+        if (validated) {
+            return;
+        }
+        validated = true;
+        for (String id : allowedBrews.keySet()) {
+            if (findBrewRecipe(id) == null) {
+                FactoryMod.getInstance().warning("Recipe " + name + " allows the brew " + id
+                    + ", but BreweryX has no brew with that id. Allow list entries are brew ids, not brew names.");
+            }
+        }
+    }
+
+    /**
+     * Looks a brew up by id. BRecipe#getById matches case sensitively, but we hold the allow list lower cased, so it
+     * cannot be used here
+     */
+    private static @Nullable BRecipe findBrewRecipe(String id) {
+        for (BRecipe recipe : BRecipe.getAllRecipes()) {
+            if (id.equalsIgnoreCase(recipe.getId())) {
+                return recipe;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<ItemStack> getInputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
+        List<ItemStack> result = new LinkedList<>();
+        if (i == null) {
+            result.add(new ItemStack(Material.POTION));
+            result.addAll(input.getItemStackRepresentation());
+            return result;
+        }
+        result = createLoredStacksForInfo(i);
+        Candidate candidate = findCandidate(i);
+        if (candidate != null) {
+            result.add(candidate.source().clone());
+        }
+        return result;
+    }
+
+    @Override
+    public List<ItemStack> getOutputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
+        List<ItemStack> result = new LinkedList<>();
+        if (i == null) {
+            result.add(new ItemStack(Material.POTION));
+            return result;
+        }
+        Candidate candidate = findCandidate(i);
+        if (candidate != null) {
+            result.add(preview(candidate));
+        }
+        return result;
+    }
+
+    @Override
+    public List<String> getTextualInputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
+        List<String> result = new LinkedList<>(formatLore(input));
+        if (sealUnsealed) {
+            result.add("A brew from the list below, sealed or not");
+            result.add("Unsealed brews are sealed first, which rounds an odd quality down");
+        } else {
+            result.add("A sealed brew from the list below");
+        }
+        return result;
+    }
+
+    @Override
+    public List<String> getTextualOutputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
+        List<String> result = new LinkedList<>();
+        for (Map.Entry<String, Integer> entry : allowedBrews.entrySet()) {
+            result.add(displayName(entry.getKey()) + ", stackable to " + entry.getValue());
+        }
+        return result;
+    }
+
+    /**
+     * The brew's name as players know it, falling back to the raw id while BreweryX can't resolve it
+     */
+    private String displayName(String id) {
+        if (Bukkit.getPluginManager().isPluginEnabled("BreweryX")) {
+            BRecipe recipe = findBrewRecipe(id);
+            if (recipe != null) {
+                return recipe.getRecipeName();
+            }
+        }
+        return id;
+    }
+
+    @Override
+    public Material getRecipeRepresentationMaterial() {
+        return Material.POTION;
+    }
+
+    @Override
+    public String getTypeIdentifier() {
+        return "BREW_STACK";
+    }
+
+    public int getDefaultStackSize() {
+        return defaultStackSize;
+    }
+
+    public boolean isSealUnsealed() {
+        return sealUnsealed;
+    }
+
+    public String getPackedLore() {
+        return packedLore;
+    }
+
+    /**
+     * Copy of the allow list, so an inheriting recipe doesn't share the parent's instance
+     */
+    public Map<String, Integer> copyAllowedBrews() {
+        return new LinkedHashMap<>(allowedBrews);
+    }
+
+    private record Candidate(ItemStack source, int maxStackSize) {
+
+    }
+}

--- a/plugins/factorymod-paper/src/main/resources/config.yml
+++ b/plugins/factorymod-paper/src/main/resources/config.yml
@@ -693,6 +693,63 @@ factories:
 
 #appliedLore is the lore which is applied as replacement for the removed lore. This list may not be empty, but it may contain multiple entries
 
+
+#10. Brew stacking recipe
+
+#This type of recipe makes BreweryX brews stackable. Brews are potions, which vanilla caps at a stack size of one, so every
+#single bottle takes up a whole inventory slot. This recipe takes one brew at a time and hands back the very same brew with
+#the vanilla max stack size set on it, so bottles of it merge into one slot from then on. The brew stays a real brew and can
+#still be drunk, and the resulting stacks split and merge like any other item.
+
+#This recipe requires the BreweryX plugin. If it isn't enabled the recipe is skipped with a warning on startup.
+
+#A brew has to be sealed before it can stack. Sealing throws away the brewing details and rounds an odd quality down to the
+#next even one (1 becomes 2, 3 becomes 2, 5 becomes 4), and it cannot be undone, exactly as BreweryX's own sealing table does.
+
+#Example:
+
+#packBrews:
+#   type: BREW_STACK
+#   name: Pack Brews
+#   production_time: 2s
+#   input:
+#       glass_bottle:
+#           material: GLASS_BOTTLE
+#           amount: 1
+#   max_stack_size: 16
+#   seal_unsealed: true
+#   packed_lore: Packed Brew ({size})
+#   allowed_brews:
+#       wheatbeer: 16
+#       mead: 8
+#       whiskey: 8
+
+
+#type always has to be BREW_STACK for this type of recipe
+
+#input specifies the cost consumed for each brew made stackable, on top of the brew itself. It may be left empty
+
+#allowed_brews is the list of brews this recipe will accept, and nothing else will be touched. Entries are keyed by BREW ID,
+#which is the yaml key of the brew in BreweryX's own config, NOT its display name. So for a BreweryX recipe written as
+#  wheatbeer:
+#    name: Skunky Wheatbeer/Wheatbeer/Fine Wheatbeer
+#the entry here is 'wheatbeer'. An id that BreweryX doesn't know is reported with a warning the first time the factory runs.
+
+#Each entry's value is the stack size for that brew, so rarer brews can be made to stack less than cheap ones. It may also be
+#written as a section with max_stack_size in it, or allowed_brews can be a plain list of ids which all use max_stack_size.
+
+#max_stack_size is the stack size used for brews which don't name their own. It has to be between 2 and 99. Defaults to 16
+
+#seal_unsealed decides what happens to a brew that isn't sealed yet. When true the factory seals it as part of the run, when
+#false only already sealed brews are accepted and everything else is left alone. Defaults to true
+
+#packed_lore is an optional line of lore added to brews the factory has made stackable, so players can tell them apart from
+#ordinary ones. Leave it out for no lore. The placeholder {size} in it is replaced with the stack size that brew got, so
+#'Packed Brew ({size})' comes out as 'Packed Brew (16)' on a brew allowed to stack to 16
+
+#Note that a brew which is already stackable is skipped, so feeding one back in will never consume the input cost again
+
+
 #GENERAL NOTE:
 
 # Every recipe type can include at the same level as "name: " the following, although only FCC's will respect it currently:

--- a/plugins/factorymod-paper/src/main/resources/plugin.yml
+++ b/plugins/factorymod-paper/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: com.github.igotyou.FactoryMod.FactoryMod
 author: Maxopoly, igotyou
 version: ${version}
 depend: [ CivModCore ]
-softdepend: [ CivMenu, NameLayer, Citadel, Heliodor, Zorweth ]
+softdepend: [ CivMenu, NameLayer, Citadel, Heliodor, Zorweth, BreweryX ]
 permissions:
   fm.public:
     default: true


### PR DESCRIPTION
## What

Adds a `BREW_STACK` recipe type to FactoryMod and a **Brew Packer** factory that makes BreweryX brews stackable.

Brews are potions, which vanilla caps at a stack size of one, so every bottle takes a whole inventory slot and bulk trade and transport are painful. The recipe hands back the *same brew* with the vanilla `max_stack_size` component set on it, so bottles merge into a single slot while staying real, drinkable, BreweryX readable brews. Stacks split and merge like any other item.

## How it works

- **Sealing is required.** BreweryX writes a fresh random scramble id into an unsealed brew on every save, so no two unsealed brews are ever equal and they could never stack. Pre-sealed brews are accepted as they are; unsealed ones are sealed during the run when `seal_unsealed` is on. Sealing is irreversible and rounds an odd quality down to the next even one, exactly as BreweryX's own sealing table does.
- **Sealed brews are inert.** `Brew#age`, `Brew#distillSlot` and `Brew#canDistill` all short circuit on `immutable`, and `BSealer` / `MCBarrel` guard on `isStripped` / `isStatic`, so a stack cannot be aged, distilled or re-sealed in bulk. No duplication vector through BreweryX's mechanics.
- **Allow list only**, keyed by BreweryX **brew id** (the yaml key in BreweryX's config) rather than display name. The id is stable across renames and unique by construction, whereas the name is a `bad/normal/good` triplet that is easy to pick the wrong part of. Ids cannot be checked at parse time because BreweryX loads `POSTWORLD`, so unknown ones are reported once on first use rather than failing silently.
- **Per brew stack sizes**, so spirits can stack lower than everyday brews.
- **Already packed brews are skipped**, so feeding one back in never charges the cost twice.

## Drinking from a stack

This needed a fix. BreweryX swaps the potion for a plain one in `PlayerItemConsumeEvent` so vanilla does not apply its effects, which sends the server down the branch that finishes using the *replacement* rather than the held stack and then calls `setItemInHand`, overwriting the stack wholesale. Without this, drinking one brew off a stack of sixteen would leave the player holding a single glass bottle and destroy the other fifteen.

`BrewStackListener` sets the event's replacement to the rest of the stack and hands the empty bottle over separately, since overriding the replacement drops the one the server made. Stacks now drain a bottle at a time, the way eating from a stack of food does. It runs after BreweryX's handler (`HIGHEST`) so a drink refused in creative or by `BPlayer#drink` is left alone.

## Config

`BREW_STACK` is documented in the plugin's default `config.yml`. The live factory is added to both the paper and zorweth FactoryMod configs:

```yaml
  pack_brews:
    production_time: 2s
    name: Pack Brews
    type: BREW_STACK
    input:
      glass_bottle: { type: GLASS_BOTTLE, amount: 1 }
    max_stack_size: 16
    seal_unsealed: true
    packed_lore: Packed Brew ({size})
    allowed_brews:
      wheatbeer: 16
      beer: 16
      darkbeer: 16
      mead: 8
      whiskey: 8
      vodka: 4
```

`allowed_brews` also accepts a plain list of ids, and `{size}` in `packed_lore` is replaced with that brew's limit.

BreweryX is a `compileOnly` dependency on the jar already vendored in `ansible/src/paper-plugins`, matching zorweth, kitpvp and simpleadminhacks, and is a `softdepend` — without it the recipe is skipped with a warning and the listener is not registered.

## Testing

**This has not been run on a server yet.** It compiles and the behaviour was traced through Paper, CraftBukkit and BreweryX source, but FactoryMod has no test suite so there is no runtime evidence. Reviewers should treat the following as unverified:

- Factory formation, since setup cost uses `containedExactlyIn` and a wrong amount just makes the crafting table silently do nothing
- Drinking from a stack: stack drops by exactly one, one glass bottle arrives, drunkenness applies once, no hand-slot desync; plus creative mode and the last bottle off a stack
- Packing from both sealed and unsealed input, and that output merges to the configured size
- Allow list rejection, repack skipping, per brew sizes, full output chest, and the unknown-id warning firing once

## Balance note

Setup cost and the allow list are a starting point, not settled balance. Both are effectively permanent once players hold stock: the `max_stack_size` component stays on the item, and brews packed at different sizes or under different `packed_lore` will not stack with each other, so these are best fixed before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
