### PR TITLE
Kick existing on duplicate session

### DIFF
--- a/ansible/files/proxy-config/velocity.toml
+++ b/ansible/files/proxy-config/velocity.toml
@@ -49,7 +49,7 @@ announce-forge = false
 
 # If enabled (default is false) and the proxy is in online mode, Velocity will kick
 # any existing player who is online if a duplicate connection attempt is made.
-kick-existing-players = false
+kick-existing-players = true
 
 # Should Velocity pass server list ping requests to a backend server?
 # Available options:


### PR DESCRIPTION
I have a really bad connection and sometimes have to wait a minute or two after (being) disconnected to rejoin as I am "already connected to this proxy". I think this kicks whatever is stuck on the server when I try to rejoin.