### PR TITLE
Add pale oak saplings to SaplingHack

### DIFF
--- a/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/SaplingHack.java
+++ b/plugins/simpleadminhacks-paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/SaplingHack.java
@@ -82,6 +82,7 @@ public class SaplingHack extends SimpleHack<SaplingConfig> implements Listener {
             case AZALEA_LEAVES -> Material.AZALEA;
             case MANGROVE_LEAVES -> Material.MANGROVE_PROPAGULE;
             case CHERRY_LEAVES -> Material.CHERRY_SAPLING;
+            case PALE_OAK_LEAVES -> Material.PALE_OAK_SAPLING;
             //We set this to air so nothing will drop if it comes to erroring
             //This needs to be updated any time a new tree is added, can we make it better?
             default -> Material.AIR;


### PR DESCRIPTION
It's currently already in the config to drop more saplings, but it doesn't work because the leaves hadn't been mapped to the saplings in code yet.