### PR TITLE
Lower player/rocket weight & add advanced fuel refining

### DIFF
--- a/ansible/files/paper-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/paper-config/plugins/FactoryMod/config.yml
@@ -112,6 +112,7 @@ factories:
       - research_phase_2
       - make_armour_repair_kit
       - refine_crude_oil
+      - advanced_refine_crude_oil
       - make_space_chem_factory_kit
       - repair_space_chem_factory
       - repair_space_chem_factory_kit
@@ -20121,6 +20122,35 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: GLOWSTONE_DUST
         amount: 128
+    output:
+      rocket_fuel:
+        custom-key: rocket_fuel
+        amount: 8
+  advanced_refine_crude_oil:
+    production_time: 64s
+    fuel_consumption_intervall: 16s
+    name: Refine Crude Oil
+    type: PRODUCTION
+    input:
+      crude_oil:
+        custom-key: crude_oil
+        amount: 64
+      glowstone_dust:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GLOWSTONE_DUST
+        amount: 48
+      salt:
+        ==: org.bukkit.inventory.ItemStack
+        v: 3839
+        type: SUGAR
+        amount: 16
+        meta:
+          ==: ItemMeta
+          meta-type: UNSPECIFIC
+          display-name: Salt
+          lore:
+            - Gathered from the Zorweth salt flats
     output:
       rocket_fuel:
         custom-key: rocket_fuel

--- a/ansible/files/zorweth-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/zorweth-config/plugins/FactoryMod/config.yml
@@ -112,6 +112,7 @@ factories:
       - research_phase_2
       - make_armour_repair_kit
       - refine_crude_oil
+      - advanced_refine_crude_oil
       - make_space_chem_factory_kit
       - repair_space_chem_factory
       - repair_space_chem_factory_kit
@@ -20121,6 +20122,35 @@ recipes:
         ==: org.bukkit.inventory.ItemStack
         type: GLOWSTONE_DUST
         amount: 128
+    output:
+      rocket_fuel:
+        custom-key: rocket_fuel
+        amount: 8
+  advanced_refine_crude_oil:
+    production_time: 64s
+    fuel_consumption_intervall: 16s
+    name: Refine Crude Oil
+    type: PRODUCTION
+    input:
+      crude_oil:
+        custom-key: crude_oil
+        amount: 64
+      glowstone_dust:
+        v: 3839
+        ==: org.bukkit.inventory.ItemStack
+        type: GLOWSTONE_DUST
+        amount: 48
+      salt:
+        ==: org.bukkit.inventory.ItemStack
+        v: 3839
+        type: SUGAR
+        amount: 16
+        meta:
+          ==: ItemMeta
+          meta-type: UNSPECIFIC
+          display-name: Salt
+          lore:
+            - Gathered from the Zorweth salt flats
     output:
       rocket_fuel:
         custom-key: rocket_fuel

--- a/plugins/zorweth-paper/src/main/java/net/civmc/zorweth/flight/LaunchHandler.java
+++ b/plugins/zorweth-paper/src/main/java/net/civmc/zorweth/flight/LaunchHandler.java
@@ -50,8 +50,8 @@ public class LaunchHandler {
 
     public static final double FUEL_ITEM_MASS_KG = 4.0;
     public static final double EXHAUST_VELOCITY_METERS_PER_SECOND = 5_000.0;
-    public static final double ROCKET_DRY_MASS_KG = 200.0;
-    public static final double SITTING_PLAYER_MASS_KG = 50.0;
+    public static final double ROCKET_DRY_MASS_KG = 150.0;
+    public static final double SITTING_PLAYER_MASS_KG = 10.0;
     private static final String COMPACTED_LORE = "Compacted Item";
 
     public static FuelStatus calculateFuelStatus(final Block computer, final List<RocketManifestPassenger> passengers,


### PR DESCRIPTION
Lowers the player weight to 10 from 50 and rocket weight to 150 from 200.

This would change fuel requirement with an "empty" rocket for main -> zorweth from 400 fuel to 256
and for zorweth -> main from 140 fuel to 93

Making player travel between the two worlds a lot less costly while still keeping the item cost high.

Also adds a new recipe to the space chemistry factory that uses 64 oil, 48 glowstone and 16 salt from zorweth to make 8 fuel.

Lowering the glowstone cost and adding a new use for salt. This would also make fuel costs lower on zorweth by ease of access to salt.
