### PR TITLE
Remove glass bottles from final Elite Recipe

### DIFF
--- a/ansible/files/paper-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/paper-config/plugins/FactoryMod/config.yml
@@ -12382,16 +12382,6 @@ recipes:
           display-name: Player Essence
           lore:
             - Activity reward used to fuel pearls
-      glass_bottle:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: GLASS_BOTTLE
-        amount: 512
-        meta:
-          meta-type: UNSPECIFIC
-          ==: ItemMeta
-          lore:
-            - Compacted Item
     output:
       exp:
         v: 3839

--- a/ansible/files/zorweth-config/plugins/FactoryMod/config.yml
+++ b/ansible/files/zorweth-config/plugins/FactoryMod/config.yml
@@ -12382,16 +12382,6 @@ recipes:
           display-name: Player Essence
           lore:
             - Activity reward used to fuel pearls
-      glass_bottle:
-        v: 3839
-        ==: org.bukkit.inventory.ItemStack
-        type: GLASS_BOTTLE
-        amount: 512
-        meta:
-          meta-type: UNSPECIFIC
-          ==: ItemMeta
-          lore:
-            - Compacted Item
     output:
       exp:
         v: 3839


### PR DESCRIPTION
These are doubled, they were already in the hot bundle.
